### PR TITLE
Slå av CodeRabbit-checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  commit_status: false
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Skrur av automatiske CodeRabbit-reviews og commit-statusen, siden den bare møter rate limit nå.