### PR TITLE
Migrer frontend til TanStack Query

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import { Analytics } from "@vercel/analytics/next";
+import ReactQueryProvider from "@/providers/ReactQueryProvider";
 
 const themeScript = `(()=>{const s=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';document.documentElement.dataset.colorScheme=s;document.documentElement.style.colorScheme=s})()`;
 
@@ -39,9 +40,11 @@ export default function RootLayout({
           color: 'var(--ds-color-neutral-text-default)'
         }}
       >
-        <Navbar />
-        {children}
-        <Footer />
+        <ReactQueryProvider>
+          <Navbar />
+          {children}
+          <Footer />
+        </ReactQueryProvider>
         <Analytics />
       </body>
     </html>

--- a/components/home/StatsCards.tsx
+++ b/components/home/StatsCards.tsx
@@ -1,147 +1,59 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
 import { Activity, Code2 } from "lucide-react";
+import { useCodingStats, useRunningStats } from "./queries";
+
+const formatPace = (distanceMeters: number, movingTimeSeconds?: number) => {
+  if (typeof movingTimeSeconds !== "number" || distanceMeters <= 0) return null;
+
+  const km = distanceMeters / 1000;
+  const paceSeconds = Math.round(movingTimeSeconds / km);
+  const paceMinutes = Math.floor(paceSeconds / 60);
+  const paceRemainder = String(paceSeconds % 60).padStart(2, "0");
+
+  return `${paceMinutes}:${paceRemainder}/km`;
+};
 
 const StatsCards = () => {
   const currentYear = new Date().getFullYear();
-  const [runKm, setRunKm] = useState("...");
-  const [topRuns, setTopRuns] = useState<string[]>([]);
-  const [codingHours, setCodingHours] = useState("...");
-  const [codingLabel, setCodingLabel] = useState(`Koding i ${currentYear}`);
-  const [codingLanguages, setCodingLanguages] = useState<string[]>([]);
+  const runningStatsQuery = useRunningStats(currentYear);
+  const codingStatsQuery = useCodingStats();
+  const runDistance = runningStatsQuery.data?.distanceMeters;
+  const runKm = runningStatsQuery.isError
+    ? "Utilgjengelig"
+    : typeof runDistance === "number"
+      ? `${new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(runDistance / 1000)} km`
+      : "...";
+  const topRuns = (runningStatsQuery.data?.activities ?? [])
+    .toSorted((a, b) => b.distance - a.distance)
+    .slice(0, 3)
+    .map((activity, index) => {
+      const formattedDistance = new Intl.NumberFormat("no-NO", {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }).format(activity.distance / 1000);
+      const pace = formatPace(activity.distance, activity.movingTime);
 
-  const formatPace = (distanceMeters: number, movingTimeSeconds?: number) => {
-    if (typeof movingTimeSeconds !== "number" || distanceMeters <= 0) return null;
-
-    const km = distanceMeters / 1000;
-    const paceSeconds = Math.round(movingTimeSeconds / km);
-    const paceMinutes = Math.floor(paceSeconds / 60);
-    const paceRemainder = String(paceSeconds % 60).padStart(2, "0");
-
-    return `${paceMinutes}:${paceRemainder}/km`;
-  };
-
-  useEffect(() => {
-    let active = true;
-
-    const loadStravaStats = async () => {
-      try {
-        const [ytdResponse, activitiesResponse] = await Promise.all([
-          fetch("https://api.vuhnger.dev/strava/stats/ytd", {
-            cache: "no-store"
-          }),
-          fetch(`https://api.vuhnger.dev/strava/activities?year=${currentYear}&activity_type=Run&limit=500`, {
-            cache: "no-store"
-          })
-        ]);
-
-        if (ytdResponse.ok) {
-          const data = await ytdResponse.json();
-          const distance = data?.data?.run?.distance;
-
-          if (typeof distance === "number" && active) {
-            const km = distance / 1000;
-            const formatted = new Intl.NumberFormat("no-NO", {
-              maximumFractionDigits: 0
-            }).format(km);
-
-            setRunKm(`${formatted} km`);
-          }
-        }
-
-        if (activitiesResponse.ok) {
-          const data = await activitiesResponse.json();
-          const activities = Array.isArray(data?.data) ? data.data : [];
-
-          if (active && activities.length > 0) {
-            const topThreeRuns = activities
-              .filter((activity: { distance?: number }) => typeof activity?.distance === "number")
-              .sort(
-                (
-                  a: { distance: number },
-                  b: { distance: number }
-                ) => b.distance - a.distance
-              )
-              .slice(0, 3)
-              .map((activity: { distance: number; moving_time?: number }, index: number) => {
-                const formattedDistance = new Intl.NumberFormat("no-NO", {
-                  minimumFractionDigits: 1,
-                  maximumFractionDigits: 1
-                }).format(activity.distance / 1000);
-                const pace = formatPace(activity.distance, activity.moving_time);
-
-                return pace
-                  ? `${index + 1}. ${formattedDistance} km · ${pace}`
-                  : `${index + 1}. ${formattedDistance} km`;
-              });
-
-            setTopRuns(topThreeRuns);
-          }
-        }
-      } catch {
-        // Silent fail - keep placeholder
-      }
-    };
-
-    loadStravaStats();
-
-    return () => {
-      active = false;
-    };
-  }, [currentYear]);
-
-  useEffect(() => {
-    let active = true;
-
-    const loadWakatime = async () => {
-      try {
-        const response = await fetch("https://api.vuhnger.dev/wakatime/stats/weekly", {
-          cache: "no-store"
-        });
-
-        if (!response.ok) return;
-        const data = await response.json();
-
-        const range = data?.data?.range;
-        if (range === "last_7_days") {
-          setCodingLabel("Koding (7d)");
-        } else if (range === "all_time") {
-          setCodingLabel("Koding (all time)");
-        }
-
-        const codingCategory = data?.data?.categories?.find(
-          (category: { name?: string }) => category?.name === "Coding"
-        );
-        const totalSeconds = codingCategory?.total_seconds ?? data?.data?.total_seconds;
-
-        if (typeof totalSeconds === "number" && active) {
-          const hours = totalSeconds / 3600;
-          const formatted = new Intl.NumberFormat("no-NO", {
-            maximumFractionDigits: hours >= 10 ? 0 : 1
-          }).format(hours);
-          setCodingHours(`${formatted} t`);
-        }
-
-        const languages = Array.isArray(data?.data?.languages)
-          ? data.data.languages.slice(0, 4).map((lang: { name?: string }) => lang.name).filter(Boolean)
-          : [];
-
-        if (active && languages.length > 0) {
-          setCodingLanguages(languages as string[]);
-        }
-      } catch {
-        // Silent fail - keep placeholder
-      }
-    };
-
-    loadWakatime();
-
-    return () => {
-      active = false;
-    };
-  }, []);
+      return pace
+        ? `${index + 1}. ${formattedDistance} km · ${pace}`
+        : `${index + 1}. ${formattedDistance} km`;
+    });
+  const codingSeconds = codingStatsQuery.data?.totalSeconds;
+  const codingHours = codingStatsQuery.isError
+    ? "Utilgjengelig"
+    : typeof codingSeconds === "number"
+      ? `${new Intl.NumberFormat("no-NO", {
+          maximumFractionDigits: codingSeconds / 3600 >= 10 ? 0 : 1,
+        }).format(codingSeconds / 3600)} t`
+      : "...";
+  const codingLabel =
+    codingStatsQuery.data?.range === "last_7_days"
+      ? "Koding (7d)"
+      : codingStatsQuery.data?.range === "all_time"
+        ? "Koding (all time)"
+        : `Koding i ${currentYear}`;
+  const codingLanguages = codingStatsQuery.data?.languages ?? [];
 
   const stats = [
     {

--- a/components/home/queries.ts
+++ b/components/home/queries.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchCodingStats, fetchRunningStats } from "@/services/api/stats";
+
+const statsKeys = {
+  all: ["stats"] as const,
+  running: (year: number) => [...statsKeys.all, "running", year] as const,
+  coding: () => [...statsKeys.all, "coding"] as const,
+};
+
+const STATS_STALE_TIME = 15 * 60 * 1000;
+
+export function useRunningStats(year: number) {
+  return useQuery({
+    queryKey: statsKeys.running(year),
+    queryFn: ({ signal }) => fetchRunningStats(year, signal),
+    staleTime: STATS_STALE_TIME,
+  });
+}
+
+export function useCodingStats() {
+  return useQuery({
+    queryKey: statsKeys.coding(),
+    queryFn: ({ signal }) => fetchCodingStats(signal),
+    staleTime: STATS_STALE_TIME,
+  });
+}

--- a/components/layout/ApiStatusLink.tsx
+++ b/components/layout/ApiStatusLink.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useApiStatus } from "./queries";
 
 type ApiStatus = "unknown" | "up" | "down";
 
@@ -11,33 +11,12 @@ const statusLabels: Record<ApiStatus, string> = {
 };
 
 const ApiStatusLink = () => {
-  const [status, setStatus] = useState<ApiStatus>("unknown");
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const checkStatus = async () => {
-      try {
-        const response = await fetch("https://api.vuhnger.dev/strava/health", {
-          cache: "no-store",
-          signal: controller.signal,
-        });
-        setStatus(response.ok ? "up" : "down");
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          setStatus("down");
-        }
-      }
-    };
-
-    void checkStatus();
-    const interval = window.setInterval(checkStatus, 60000);
-
-    return () => {
-      controller.abort();
-      window.clearInterval(interval);
-    };
-  }, []);
+  const apiStatusQuery = useApiStatus();
+  const status: ApiStatus = apiStatusQuery.isPending
+    ? "unknown"
+    : apiStatusQuery.isError || !apiStatusQuery.data
+      ? "down"
+      : "up";
 
   return (
     <a

--- a/components/layout/queries.ts
+++ b/components/layout/queries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchApiStatus } from "@/services/api/client";
+
+export function useApiStatus() {
+  return useQuery({
+    queryKey: ["api-status"],
+    queryFn: ({ signal }) => fetchApiStatus(signal),
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@digdir/designsystemet-react": "^1.18.0",
     "@digdir/designsystemet-theme": "^1.11.0",
     "@hookform/resolvers": "^5.4.0",
+    "@tanstack/react-query": "^5.101.3",
     "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -32,13 +33,13 @@
     "react-hook-form": "^7.72.1",
     "react-icons": "^5.7.0",
     "react-snowfall": "^2.4.0",
-    "swr": "^2.4.1",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
     "@tailwindcss/postcss": "^4",
+    "@tanstack/react-query-devtools": "^5.101.3",
     "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.82.0(react@19.2.8))
+      '@tanstack/react-query':
+        specifier: ^5.101.3
+        version: 5.101.3(react@19.2.8)
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.2.6(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -59,9 +62,6 @@ importers:
       react-snowfall:
         specifier: ^2.4.0
         version: 2.4.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
-      swr:
-        specifier: ^2.4.1
-        version: 2.4.2(react@19.2.8)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
@@ -75,6 +75,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.3
+        version: 5.101.3(@tanstack/react-query@5.101.3(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^26
         version: 26.1.1
@@ -672,6 +675,23 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
+  '@tanstack/query-core@5.101.3':
+    resolution: {integrity: sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==}
+
+  '@tanstack/query-devtools@5.101.3':
+    resolution: {integrity: sha512-twEAOB5uBmpFAdlIuy3KIUujwmoZIhCXZpu1PFMTress2XvK/CyzsvV70WrhtTcocszKpbvwMR0Bxq4dqkvH0g==}
+
+  '@tanstack/react-query-devtools@5.101.3':
+    resolution: {integrity: sha512-Xr4gCymObeVmtImtsPDVzOlvy3Itr2ti3IrtdbcyhsmpsM54v2A7VR9hTB40C6wzCf3yM4Q2LqkFbNm1u8wd3A==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.3
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.3':
+    resolution: {integrity: sha512-ZjgcRwmQUSCythDPj6pE2NKFi9bpQegxIBxgt3hPytXI1ElFHNaa3A7aWW8vFaLCIRjPv467rbREYHbxcdgQbg==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tanstack/react-virtual@3.14.7':
     resolution: {integrity: sha512-11uSrj77IDijNBqizD4lY4y1laMyRrqMLSxjnWy5CvWkCjyRDW+gGmxYq0lwQKVas/sq7zyzYWXbL/BvBzR32g==}
     peerDependencies:
@@ -1230,10 +1250,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2197,11 +2213,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swr@2.4.2:
-    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
@@ -2293,11 +2304,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2847,6 +2853,21 @@ snapshots:
       postcss: 8.5.20
       tailwindcss: 4.3.3
 
+  '@tanstack/query-core@5.101.3': {}
+
+  '@tanstack/query-devtools@5.101.3': {}
+
+  '@tanstack/react-query-devtools@5.101.3(@tanstack/react-query@5.101.3(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.3
+      '@tanstack/react-query': 5.101.3(react@19.2.8)
+      react: 19.2.8
+
+  '@tanstack/react-query@5.101.3(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.3
+      react: 19.2.8
+
   '@tanstack/react-virtual@3.14.7(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.5
@@ -3325,8 +3346,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -4499,12 +4518,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swr@2.4.2(react@19.2.8):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.8
-      use-sync-external-store: 1.6.0(react@19.2.8)
-
   tabbable@6.5.0: {}
 
   tailwind-merge@3.6.0: {}
@@ -4655,10 +4668,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.6.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/providers/ReactQueryProvider.tsx
+++ b/providers/ReactQueryProvider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+export default function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 60 * 1000,
+            gcTime: 30 * 60 * 1000,
+            retry: 2,
+            refetchOnWindowFocus: true,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -1,0 +1,23 @@
+const API_BASE_URL = "https://api.vuhnger.dev";
+
+export async function fetchApi<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    cache: "no-store",
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`API-kallet feilet med status ${response.status}.`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function fetchApiStatus(signal?: AbortSignal): Promise<boolean> {
+  const response = await fetch(`${API_BASE_URL}/strava/health`, {
+    cache: "no-store",
+    signal,
+  });
+
+  return response.ok;
+}

--- a/services/api/stats.ts
+++ b/services/api/stats.ts
@@ -1,0 +1,117 @@
+import { fetchApi } from "./client";
+
+type StravaYtdResponse = {
+  data?: {
+    run?: {
+      distance?: unknown;
+    };
+  };
+};
+
+type StravaActivitiesResponse = {
+  data?: unknown;
+};
+
+type WakaTimeResponse = {
+  data?: {
+    range?: unknown;
+    categories?: unknown;
+    total_seconds?: unknown;
+    languages?: unknown;
+  };
+};
+
+export type RunningActivity = {
+  distance: number;
+  movingTime?: number;
+};
+
+export type RunningStats = {
+  distanceMeters?: number;
+  activities: RunningActivity[];
+};
+
+export type CodingStats = {
+  range?: string;
+  totalSeconds?: number;
+  languages: string[];
+};
+
+export async function fetchRunningStats(year: number, signal?: AbortSignal): Promise<RunningStats> {
+  const [ytd, activitiesResponse] = await Promise.all([
+    fetchApi<StravaYtdResponse>("/strava/stats/ytd", signal),
+    fetchApi<StravaActivitiesResponse>(
+      `/strava/activities?year=${year}&activity_type=Run&limit=500`,
+      signal,
+    ),
+  ]);
+
+  const distance = ytd.data?.run?.distance;
+  const activities = Array.isArray(activitiesResponse.data)
+    ? activitiesResponse.data.flatMap((activity): RunningActivity[] => {
+        if (typeof activity !== "object" || activity === null || !("distance" in activity)) {
+          return [];
+        }
+
+        const activityDistance = activity.distance;
+        if (typeof activityDistance !== "number") return [];
+
+        const movingTime = "moving_time" in activity ? activity.moving_time : undefined;
+        return [
+          {
+            distance: activityDistance,
+            movingTime: typeof movingTime === "number" ? movingTime : undefined,
+          },
+        ];
+      })
+    : [];
+
+  return {
+    distanceMeters: typeof distance === "number" ? distance : undefined,
+    activities,
+  };
+}
+
+export async function fetchCodingStats(signal?: AbortSignal): Promise<CodingStats> {
+  const response = await fetchApi<WakaTimeResponse>("/wakatime/stats/weekly", signal);
+  const data = response.data;
+  const categories = Array.isArray(data?.categories) ? data.categories : [];
+  const codingCategory = categories.find(
+    (category) =>
+      typeof category === "object" &&
+      category !== null &&
+      "name" in category &&
+      category.name === "Coding",
+  );
+  const categorySeconds =
+    typeof codingCategory === "object" &&
+    codingCategory !== null &&
+    "total_seconds" in codingCategory
+      ? codingCategory.total_seconds
+      : undefined;
+  const languages = Array.isArray(data?.languages)
+    ? data.languages.flatMap((language): string[] => {
+        if (
+          typeof language === "object" &&
+          language !== null &&
+          "name" in language &&
+          typeof language.name === "string"
+        ) {
+          return [language.name];
+        }
+        return [];
+      })
+    : [];
+  const totalSeconds =
+    typeof categorySeconds === "number"
+      ? categorySeconds
+      : typeof data?.total_seconds === "number"
+        ? data.total_seconds
+        : undefined;
+
+  return {
+    range: typeof data?.range === "string" ? data.range : undefined,
+    totalSeconds,
+    languages: languages.slice(0, 4),
+  };
+}


### PR DESCRIPTION
Flytter API-kallene ut av komponentene og over til TanStack Query med caching, automatisk refetch og ryddige loading- og error-states. Fjerner samtidig den ubrukte SWR-avhengigheten.