### PR TITLE
Gjeninnfør React Query med server-prefetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,16 @@ deployment work.
 
 These repository-specific rules override generic instructions that use `main`
 as the base branch.
+
+## Frontend data fetching
+
+- Use TanStack Query for application API data and other client-visible server
+  state. Keep query keys and query options in feature-local `queries.ts` files.
+- In the Next.js App Router, prefetch queries in Server Components and pass the
+  dehydrated cache through `HydrationBoundary`. Do not replace this with a
+  client-only request waterfall.
+- Keep runtime validation at the API boundary. Query generics do not validate
+  external JSON, so parse responses with Zod before they enter the query cache.
+- Configure polling and focus refetching only when the product needs that
+  freshness. Prefer an explicit `staleTime` and Next.js fetch revalidation for
+  slowly changing public data.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import { Analytics } from "@vercel/analytics/next";
+import ReactQueryProvider from "@/providers/ReactQueryProvider";
 
 const themeScript = `(()=>{let s;try{s=localStorage.getItem('color-scheme')}catch{}if(s!=='light'&&s!=='dark')s=matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';document.documentElement.dataset.colorScheme=s;document.documentElement.style.colorScheme=s})()`;
 
@@ -39,9 +40,11 @@ export default function RootLayout({
           color: 'var(--ds-color-neutral-text-default)'
         }}
       >
-        <Navbar />
-        {children}
-        <Footer />
+        <ReactQueryProvider>
+          <Navbar />
+          {children}
+          <Footer />
+        </ReactQueryProvider>
         <Analytics />
       </body>
     </html>

--- a/components/home/BentoGrid.tsx
+++ b/components/home/BentoGrid.tsx
@@ -6,7 +6,8 @@ import { FaLinkedinIn, FaStrava } from "react-icons/fa";
 import { FiFileText, FiGrid } from "react-icons/fi";
 import { Suspense } from "react";
 import MasterCountdown from "./MasterCountdown";
-import StatsCards, { StatsCardsLoading } from "./StatsCards";
+import { StatsCardsLoading } from "./StatsCards";
+import PrefetchedStatsCards from "./PrefetchedStatsCards";
 
 const BentoGrid = () => {
   const clickableOutline = '2px solid var(--ds-color-accent-base-default)';
@@ -238,7 +239,7 @@ const BentoGrid = () => {
           <MasterCountdown />
         </div>
         <Suspense fallback={<StatsCardsLoading />}>
-          <StatsCards />
+          <PrefetchedStatsCards />
         </Suspense>
       </div>
     </div>

--- a/components/home/PrefetchedStatsCards.tsx
+++ b/components/home/PrefetchedStatsCards.tsx
@@ -1,0 +1,27 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { createQueryClient } from "@/lib/query-client";
+import StatsCards from "./StatsCards";
+import {
+  codingStatsQueryOptions,
+  runningActivitiesQueryOptions,
+  runningDistanceQueryOptions,
+} from "./queries";
+
+const PrefetchedStatsCards = async () => {
+  const currentYear = new Date().getFullYear();
+  const queryClient = createQueryClient(false);
+
+  await Promise.all([
+    queryClient.prefetchQuery(runningDistanceQueryOptions()),
+    queryClient.prefetchQuery(runningActivitiesQueryOptions(currentYear)),
+    queryClient.prefetchQuery(codingStatsQueryOptions()),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <StatsCards currentYear={currentYear} />
+    </HydrationBoundary>
+  );
+};
+
+export default PrefetchedStatsCards;

--- a/components/home/StatsCards.tsx
+++ b/components/home/StatsCards.tsx
@@ -1,6 +1,13 @@
+"use client";
+
 import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
+import { useQuery } from "@tanstack/react-query";
 import { Activity, Code2 } from "lucide-react";
-import { fetchCodingStats, fetchRunningStats } from "@/services/api/stats";
+import {
+  codingStatsQueryOptions,
+  runningActivitiesQueryOptions,
+  runningDistanceQueryOptions,
+} from "./queries";
 
 const formatPace = (distanceMeters: number, movingTimeSeconds?: number) => {
   if (typeof movingTimeSeconds !== "number" || distanceMeters <= 0) return null;
@@ -35,21 +42,18 @@ export const StatsCardsLoading = () => (
   </>
 );
 
-const StatsCards = async () => {
-  const currentYear = new Date().getFullYear();
-  const [runningResult, codingResult] = await Promise.allSettled([
-    fetchRunningStats(currentYear),
-    fetchCodingStats(),
-  ]);
-  const runningStats = runningResult.status === "fulfilled" ? runningResult.value : undefined;
-  const codingStats = codingResult.status === "fulfilled" ? codingResult.value : undefined;
-  const runDistance = runningStats?.distanceMeters;
-  const runKm = !runningStats || runningStats.distanceError
+const StatsCards = ({ currentYear }: { currentYear: number }) => {
+  const distanceQuery = useQuery(runningDistanceQueryOptions());
+  const activitiesQuery = useQuery(runningActivitiesQueryOptions(currentYear));
+  const codingQuery = useQuery(codingStatsQueryOptions());
+  const codingStats = codingQuery.data;
+  const runDistance = distanceQuery.data;
+  const runKm = distanceQuery.isError
     ? "Utilgjengelig"
     : typeof runDistance === "number"
       ? `${new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(runDistance / 1000)} km`
       : "...";
-  const topRuns = (runningStats?.activities ?? [])
+  const topRuns = (activitiesQuery.data ?? [])
     .toSorted((a, b) => b.distance - a.distance)
     .slice(0, 3)
     .map((activity, index) => {
@@ -64,7 +68,7 @@ const StatsCards = async () => {
         : `${index + 1}. ${formattedDistance} km`;
     });
   const codingSeconds = codingStats?.totalSeconds;
-  const codingHours = !codingStats
+  const codingHours = codingQuery.isError
     ? "Utilgjengelig"
     : typeof codingSeconds === "number"
       ? `${new Intl.NumberFormat("no-NO", {
@@ -108,7 +112,7 @@ const StatsCards = async () => {
       value: runKm,
       label: `Strava km i ${currentYear}`,
       color: "var(--ds-color-brand2-base-default)",
-      extra: runningStats?.activitiesError ? (
+      extra: activitiesQuery.isError ? (
         <Paragraph data-size="xs" style={{ margin: 0, opacity: 0.78 }}>
           Aktiviteter utilgjengelig
         </Paragraph>

--- a/components/home/queries.ts
+++ b/components/home/queries.ts
@@ -1,0 +1,29 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  fetchCodingStats,
+  fetchRunningActivities,
+  fetchRunningDistance,
+} from "@/services/api/stats";
+
+export const STATS_STALE_TIME = 10 * 60 * 1000;
+
+export const runningDistanceQueryOptions = () =>
+  queryOptions({
+    queryKey: ["stats", "running", "distance"] as const,
+    queryFn: ({ signal }) => fetchRunningDistance(signal),
+    staleTime: STATS_STALE_TIME,
+  });
+
+export const runningActivitiesQueryOptions = (year: number) =>
+  queryOptions({
+    queryKey: ["stats", "running", "activities", year] as const,
+    queryFn: ({ signal }) => fetchRunningActivities(year, signal),
+    staleTime: STATS_STALE_TIME,
+  });
+
+export const codingStatsQueryOptions = () =>
+  queryOptions({
+    queryKey: ["stats", "coding"] as const,
+    queryFn: ({ signal }) => fetchCodingStats(signal),
+    staleTime: STATS_STALE_TIME,
+  });

--- a/components/layout/ApiStatusLink.tsx
+++ b/components/layout/ApiStatusLink.tsx
@@ -1,23 +1,18 @@
-import { z } from "zod";
-import { fetchApi } from "@/services/api/client";
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { apiStatusQueryOptions } from "./queries";
 
 type ApiStatus = "up" | "down";
-
-const apiHealthSchema = z.object({
-  status: z.literal("ok"),
-  service: z.string(),
-  database: z.string(),
-});
 
 const statusLabels: Record<ApiStatus, string> = {
   up: "API-et er tilgjengelig",
   down: "API-et er utilgjengelig",
 };
 
-const ApiStatusLink = async () => {
-  const status: ApiStatus = await fetchApi("/strava/health", apiHealthSchema)
-    .then(() => "up" as const)
-    .catch(() => "down" as const);
+const ApiStatusLink = () => {
+  const statusQuery = useQuery(apiStatusQueryOptions());
+  const status: ApiStatus = statusQuery.isError || !statusQuery.data ? "down" : "up";
 
   return (
     <a

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,7 +1,7 @@
 import NextLink from "next/link";
 import { House } from "lucide-react";
 import { Suspense } from "react";
-import ApiStatusLink from "./ApiStatusLink";
+import PrefetchedApiStatusLink from "./PrefetchedApiStatusLink";
 import ThemeToggle from "./ThemeToggle";
 
 const Navbar = () => {
@@ -36,7 +36,7 @@ const Navbar = () => {
           </NextLink>
 
           <Suspense fallback={null}>
-            <ApiStatusLink />
+            <PrefetchedApiStatusLink />
           </Suspense>
         </div>
 

--- a/components/layout/PrefetchedApiStatusLink.tsx
+++ b/components/layout/PrefetchedApiStatusLink.tsx
@@ -1,0 +1,17 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { createQueryClient } from "@/lib/query-client";
+import ApiStatusLink from "./ApiStatusLink";
+import { apiStatusQueryOptions } from "./queries";
+
+const PrefetchedApiStatusLink = async () => {
+  const queryClient = createQueryClient(false);
+  await queryClient.prefetchQuery(apiStatusQueryOptions());
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ApiStatusLink />
+    </HydrationBoundary>
+  );
+};
+
+export default PrefetchedApiStatusLink;

--- a/components/layout/queries.ts
+++ b/components/layout/queries.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from "@tanstack/react-query";
+import { z } from "zod";
+import { fetchApi } from "@/services/api/client";
+
+const apiHealthSchema = z.object({
+  status: z.literal("ok"),
+  service: z.string(),
+  database: z.string(),
+});
+
+export const apiStatusQueryOptions = () =>
+  queryOptions({
+    queryKey: ["api-status"] as const,
+    queryFn: async ({ signal }) => {
+      await fetchApi("/strava/health", apiHealthSchema, signal);
+      return true;
+    },
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });

--- a/lib/query-client.ts
+++ b/lib/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const createQueryClient = (retry: boolean | number = 1) =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000,
+        retry,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@digdir/designsystemet-react": "^1.18.0",
     "@digdir/designsystemet-theme": "^1.11.0",
     "@hookform/resolvers": "^5.4.0",
+    "@tanstack/react-query": "^5.101.3",
     "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
     "@tailwindcss/postcss": "^4",
+    "@tanstack/react-query-devtools": "^5.101.3",
     "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.82.0(react@19.2.8))
+      '@tanstack/react-query':
+        specifier: ^5.101.3
+        version: 5.101.3(react@19.2.8)
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.2.6(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -69,6 +72,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.3
+        version: 5.101.3(@tanstack/react-query@5.101.3(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^26
         version: 26.1.1
@@ -781,6 +787,23 @@ packages:
 
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
+
+  '@tanstack/query-core@5.101.3':
+    resolution: {integrity: sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==}
+
+  '@tanstack/query-devtools@5.101.3':
+    resolution: {integrity: sha512-twEAOB5uBmpFAdlIuy3KIUujwmoZIhCXZpu1PFMTress2XvK/CyzsvV70WrhtTcocszKpbvwMR0Bxq4dqkvH0g==}
+
+  '@tanstack/react-query-devtools@5.101.3':
+    resolution: {integrity: sha512-Xr4gCymObeVmtImtsPDVzOlvy3Itr2ti3IrtdbcyhsmpsM54v2A7VR9hTB40C6wzCf3yM4Q2LqkFbNm1u8wd3A==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.3
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.3':
+    resolution: {integrity: sha512-ZjgcRwmQUSCythDPj6pE2NKFi9bpQegxIBxgt3hPytXI1ElFHNaa3A7aWW8vFaLCIRjPv467rbREYHbxcdgQbg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.14.7':
     resolution: {integrity: sha512-11uSrj77IDijNBqizD4lY4y1laMyRrqMLSxjnWy5CvWkCjyRDW+gGmxYq0lwQKVas/sq7zyzYWXbL/BvBzR32g==}
@@ -3193,6 +3216,21 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       postcss: 8.5.20
       tailwindcss: 4.3.3
+
+  '@tanstack/query-core@5.101.3': {}
+
+  '@tanstack/query-devtools@5.101.3': {}
+
+  '@tanstack/react-query-devtools@5.101.3(@tanstack/react-query@5.101.3(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.3
+      '@tanstack/react-query': 5.101.3(react@19.2.8)
+      react: 19.2.8
+
+  '@tanstack/react-query@5.101.3(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.3
+      react: 19.2.8
 
   '@tanstack/react-virtual@3.14.7(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
     dependencies:

--- a/providers/ReactQueryProvider.tsx
+++ b/providers/ReactQueryProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { createQueryClient } from "@/lib/query-client";
+
+const ReactQueryProvider = ({ children }: { children: ReactNode }) => {
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+};
+
+export default ReactQueryProvider;

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -1,14 +1,22 @@
 import { z } from "zod";
 
 const API_BASE_URL = "https://api.vuhnger.dev";
-const API_REVALIDATE_SECONDS = 15 * 60;
+const API_REVALIDATE_SECONDS = 5 * 60;
+const API_TIMEOUT_MS = 5_000;
 
 export async function fetchApi<TSchema extends z.ZodType>(
   path: string,
   schema: TSchema,
+  signal?: AbortSignal,
 ): Promise<z.output<TSchema>> {
+  const options =
+    typeof window === "undefined"
+      ? { next: { revalidate: API_REVALIDATE_SECONDS } }
+      : undefined;
+  const timeoutSignal = AbortSignal.timeout(API_TIMEOUT_MS);
   const response = await fetch(`${API_BASE_URL}${path}`, {
-    next: { revalidate: API_REVALIDATE_SECONDS },
+    ...options,
+    signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
   });
 
   if (!response.ok) {

--- a/services/api/stats.ts
+++ b/services/api/stats.ts
@@ -32,47 +32,35 @@ export type RunningActivity = {
   movingTime?: number;
 };
 
-export type RunningStats = {
-  distanceMeters?: number;
-  activities: RunningActivity[];
-  distanceError: boolean;
-  activitiesError: boolean;
-};
-
 export type CodingStats = {
   range?: string;
   totalSeconds?: number;
   languages: string[];
 };
 
-export async function fetchRunningStats(year: number): Promise<RunningStats> {
-  const [ytdResult, activitiesResult] = await Promise.allSettled([
-    fetchApi("/strava/stats/ytd", stravaYtdSchema),
-    fetchApi(
-      `/strava/activities?year=${year}&activity_type=Run&limit=500`,
-      stravaActivitiesSchema,
-    ),
-  ]);
-
-  const distance = ytdResult.status === "fulfilled" ? ytdResult.value.data.run?.distance : undefined;
-  const activities =
-    activitiesResult.status === "fulfilled"
-      ? activitiesResult.value.data.map((activity) => ({
-          distance: activity.distance,
-          movingTime: activity.moving_time,
-        }))
-      : [];
-
-  return {
-    distanceMeters: distance,
-    activities,
-    distanceError: ytdResult.status === "rejected",
-    activitiesError: activitiesResult.status === "rejected",
-  };
+export async function fetchRunningDistance(signal?: AbortSignal): Promise<number | undefined> {
+  const response = await fetchApi("/strava/stats/ytd", stravaYtdSchema, signal);
+  return response.data.run?.distance;
 }
 
-export async function fetchCodingStats(): Promise<CodingStats> {
-  const response = await fetchApi("/wakatime/stats/weekly", wakaTimeSchema);
+export async function fetchRunningActivities(
+  year: number,
+  signal?: AbortSignal,
+): Promise<RunningActivity[]> {
+  const response = await fetchApi(
+    `/strava/activities?year=${year}&activity_type=Run&limit=500`,
+    stravaActivitiesSchema,
+    signal,
+  );
+
+  return response.data.map((activity) => ({
+    distance: activity.distance,
+    movingTime: activity.moving_time,
+  }));
+}
+
+export async function fetchCodingStats(signal?: AbortSignal): Promise<CodingStats> {
+  const response = await fetchApi("/wakatime/stats/weekly", wakaTimeSchema, signal);
   const data = response.data;
   const codingCategory = data.categories?.find((category) => category.name === "Coding");
   const languages = data.languages?.map((language) => language.name) ?? [];


### PR DESCRIPTION
Beholder serverrendring og Zod-validering, men lar TanStack Query eie API-state via prefetch og hydrering. Dokumenterer samme mønster i AGENTS.md så dataflyten holder seg konsekvent videre.