### PR TITLE
feat: 404-side med algoritme-art

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { Heading, Paragraph } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
 
 import AStarVisualization from "@/components/home/AStarVisualization";
 
@@ -11,55 +10,10 @@ export default function NotFound() {
     >
       <AStarVisualization />
 
-      <div className="relative z-10 flex w-full max-w-lg flex-col items-center text-center">
-        <div
-          className="mb-6 rounded-full border px-4 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.25em]"
-          style={{
-            borderColor: "var(--ds-color-neutral-border-subtle)",
-            backgroundColor:
-              "color-mix(in srgb, var(--ds-color-neutral-surface-default) 80%, transparent)",
-            color: "var(--ds-color-neutral-text-subtle)",
-          }}
-        >
-          Feil 404
-        </div>
-
-        <p
-          className="font-mono text-7xl font-bold leading-none tracking-tight sm:text-8xl"
-          style={{ color: "var(--ds-color-accent-base-default)" }}
-          aria-hidden="true"
-        >
-          404
-        </p>
-
-        <Heading data-size="lg" style={{ marginTop: "1.25rem", marginBottom: "0.5rem" }}>
-          Ingen sti funnet
+      <div className="relative z-10 text-center">
+        <Heading data-size="lg" style={{ margin: 0 }}>
+          Oops, denne siden finnes ikke!
         </Heading>
-
-        <Paragraph
-          data-size="sm"
-          style={{ margin: 0, color: "var(--ds-color-neutral-text-default)" }}
-        >
-          Søkealgoritmen lette gjennom hele grafen, men fant ingen rute til
-          siden du er ute etter. Den finnes nok ikke – eller så har den flyttet
-          på seg.
-        </Paragraph>
-
-        <Link
-          href="/"
-          className="group mt-8 inline-flex items-center gap-2 rounded-md border px-5 py-2.5 text-sm font-semibold transition hover:-translate-y-0.5 hover:shadow-sm"
-          style={{
-            borderColor: "var(--ds-color-accent-border-default)",
-            backgroundColor:
-              "color-mix(in srgb, var(--ds-color-neutral-surface-default) 85%, transparent)",
-            color: "var(--ds-color-accent-base-default)",
-          }}
-        >
-          Tilbake til forsiden
-          <span aria-hidden="true" className="transition group-hover:translate-x-1">
-            →
-          </span>
-        </Link>
       </div>
     </main>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { Heading, Paragraph } from "@digdir/designsystemet-react";
+
+import AStarVisualization from "@/components/home/AStarVisualization";
+
+export default function NotFound() {
+  return (
+    <main
+      className="relative isolate flex min-h-screen items-center justify-center overflow-hidden px-4 py-24"
+      style={{ backgroundColor: "var(--ds-color-neutral-background-default)" }}
+    >
+      <AStarVisualization />
+
+      <div className="relative z-10 flex w-full max-w-lg flex-col items-center text-center">
+        <div
+          className="mb-6 rounded-full border px-4 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.25em]"
+          style={{
+            borderColor: "var(--ds-color-neutral-border-subtle)",
+            backgroundColor:
+              "color-mix(in srgb, var(--ds-color-neutral-surface-default) 80%, transparent)",
+            color: "var(--ds-color-neutral-text-subtle)",
+          }}
+        >
+          Feil 404
+        </div>
+
+        <p
+          className="font-mono text-7xl font-bold leading-none tracking-tight sm:text-8xl"
+          style={{ color: "var(--ds-color-accent-base-default)" }}
+          aria-hidden="true"
+        >
+          404
+        </p>
+
+        <Heading data-size="lg" style={{ marginTop: "1.25rem", marginBottom: "0.5rem" }}>
+          Ingen sti funnet
+        </Heading>
+
+        <Paragraph
+          data-size="sm"
+          style={{ margin: 0, color: "var(--ds-color-neutral-text-default)" }}
+        >
+          Søkealgoritmen lette gjennom hele grafen, men fant ingen rute til
+          siden du er ute etter. Den finnes nok ikke – eller så har den flyttet
+          på seg.
+        </Paragraph>
+
+        <Link
+          href="/"
+          className="group mt-8 inline-flex items-center gap-2 rounded-md border px-5 py-2.5 text-sm font-semibold transition hover:-translate-y-0.5 hover:shadow-sm"
+          style={{
+            borderColor: "var(--ds-color-accent-border-default)",
+            backgroundColor:
+              "color-mix(in srgb, var(--ds-color-neutral-surface-default) 85%, transparent)",
+            color: "var(--ds-color-accent-base-default)",
+          }}
+        >
+          Tilbake til forsiden
+          <span aria-hidden="true" className="transition group-hover:translate-x-1">
+            →
+          </span>
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Manglet en skikkelig 404-side, så her er en som passer resten av siden.

Gjenbruker A*-visualiseringen som allerede kjører på forsiden som bakgrunn, med en liten twist på teksten: søkealgoritmen fant "ingen sti" til siden du var ute etter. Tematisk ganske fint for en 404 spør du meg.

Server component, arver dark/light-tema og reduced-motion fra visualiseringen som allerede finnes, så ingenting nytt å vedlikeholde.