### PR TITLE
feat: SEO, OG-bilde, error boundary + opprydning og refaktor av visualiseringer

### DIFF
--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -13,7 +13,14 @@ import {
 } from "react-icons/si";
 import { FaJava, FaPython, FaReact, FaHtml5 } from "react-icons/fa";
 import { FiMail, FiChevronRight } from "react-icons/fi";
+import type { Metadata } from "next";
 import AccessibleDialog from "@/components/ui/accessible-dialog";
+
+export const metadata: Metadata = {
+  title: "CV",
+  description:
+    "Utdanning, arbeidserfaring og teknologistakk - CV-en til Victor Uhnger, utvikler og masterstudent i informatikk.",
+};
 
 type Experience = {
   id: string;

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+import { Heading, Paragraph } from "@digdir/designsystemet-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main
+      className="flex min-h-screen items-center justify-center px-4 py-24"
+      style={{ backgroundColor: "var(--ds-color-neutral-background-default)" }}
+    >
+      <div className="flex max-w-md flex-col items-center gap-4 text-center">
+        <Heading data-size="lg" style={{ margin: 0 }}>
+          Noe gikk galt
+        </Heading>
+        <Paragraph
+          data-size="sm"
+          style={{ margin: 0, color: "var(--ds-color-neutral-text-default)" }}
+        >
+          Det oppsto en uventet feil. Prøv igjen, så laster vi siden på nytt.
+        </Paragraph>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-2 inline-flex items-center gap-2 rounded-md border px-5 py-2.5 text-sm font-semibold transition hover:-translate-y-0.5 hover:shadow-sm"
+          style={{
+            borderColor: "var(--ds-color-accent-border-default)",
+            backgroundColor:
+              "color-mix(in srgb, var(--ds-color-neutral-surface-default) 85%, transparent)",
+            color: "var(--ds-color-accent-base-default)",
+          }}
+        >
+          Prøv igjen
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,9 +18,29 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_DESCRIPTION =
+  "Masterstudent i Informatikk: programmering og nettverk ved Universitetet i Oslo. Utvikler, løper, og teknologientusiast.";
+
 export const metadata: Metadata = {
-  title: "Victor Uhnger - Portfolio",
-  description: "Masterstudent i Informatikk: programmering og nettverk ved Universitetet i Oslo. Utvikler, løper, og teknologientusiast.",
+  metadataBase: new URL("https://vuhnger.dev"),
+  title: {
+    default: "Victor Uhnger - Portfolio",
+    template: "%s · Victor Uhnger",
+  },
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: "Victor Uhnger - Portfolio",
+    description: SITE_DESCRIPTION,
+    url: "/",
+    siteName: "Victor Uhnger",
+    locale: "no_NO",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Victor Uhnger - Portfolio",
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/app/master/page.tsx
+++ b/app/master/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
 import { MASTER_TIMELINE } from "@/lib/master";
 import EdgeComputingVisualization from "@/components/master/EdgeComputingVisualization";
 import MasterProgress from "@/components/master/MasterProgress";
+
+export const metadata: Metadata = {
+  title: "Master",
+  description:
+    "Om masteroppgaven min i programmering og systemarkitektur ved Universitetet i Oslo - tema, fremdrift og tidslinje.",
+};
 
 const MasterPage = () => {
   return (

--- a/app/mst/page.tsx
+++ b/app/mst/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import MstVisualization from "@/components/home/MstVisualization";
+
+export const metadata: Metadata = {
+  title: "MST",
+  description:
+    "Interaktiv visualisering av et minimum spanning tree (MST) - en av datastrukturene bak den visuelle identiteten på siden.",
+};
 
 export default function MstPage() {
   return (

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,62 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Victor Uhnger - Portfolio";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          backgroundColor: "#0f172a",
+          backgroundImage:
+            "radial-gradient(circle at 85% 15%, rgba(59,130,246,0.22), transparent 55%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+          <svg width="72" height="72" viewBox="0 0 32 32" fill="none">
+            <g
+              stroke="#3b82f6"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="9,8 17,16 9,24" />
+              <line x1="20" y1="24" x2="26" y2="24" />
+            </g>
+          </svg>
+          <span style={{ color: "#94a3b8", fontSize: "34px", fontWeight: 600 }}>
+            vuhnger.dev
+          </span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <span style={{ color: "#f8fafc", fontSize: "84px", fontWeight: 800 }}>
+            Victor Uhnger
+          </span>
+          <span style={{ color: "#cbd5e1", fontSize: "40px", fontWeight: 500 }}>
+            Masterstudent i informatikk · utvikler
+          </span>
+        </div>
+
+        <div
+          style={{
+            height: "8px",
+            width: "220px",
+            borderRadius: "9999px",
+            backgroundColor: "#3b82f6",
+          }}
+        />
+      </div>
+    ),
+    size,
+  );
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -4,7 +4,79 @@ export const alt = "Victor Uhnger - Portfolio";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+type Point = { x: number; y: number };
+type Edge = { from: Point; to: Point };
+
+// Deterministisk PRNG slik at OG-bildet blir likt for hver build.
+const mulberry32 = (seed: number) => () => {
+  seed |= 0;
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+// Kruskal + union-find på en komplett graf, samme algoritme som MST-bakgrunnen.
+const buildMst = (): { nodes: Point[]; edges: Edge[] } => {
+  const random = mulberry32(20240724);
+  const nodeCount = 16;
+  const margin = 70;
+  const minDistance = 110;
+  const nodes: Point[] = [];
+
+  for (let index = 0; index < nodeCount; index += 1) {
+    let point: Point = { x: 0, y: 0 };
+    let attempts = 0;
+    do {
+      point = {
+        x: margin + random() * (size.width - margin * 2),
+        y: margin + random() * (size.height - margin * 2),
+      };
+      attempts += 1;
+    } while (
+      attempts < 60 &&
+      nodes.some((node) => Math.hypot(node.x - point.x, node.y - point.y) < minDistance)
+    );
+    nodes.push(point);
+  }
+
+  const candidates: { a: number; b: number; weight: number }[] = [];
+  for (let a = 0; a < nodes.length; a += 1) {
+    for (let b = a + 1; b < nodes.length; b += 1) {
+      candidates.push({
+        a,
+        b,
+        weight: Math.hypot(nodes[a].x - nodes[b].x, nodes[a].y - nodes[b].y),
+      });
+    }
+  }
+  candidates.sort((first, second) => first.weight - second.weight);
+
+  const parent = nodes.map((_, index) => index);
+  const find = (value: number): number => {
+    while (parent[value] !== value) {
+      parent[value] = parent[parent[value]];
+      value = parent[value];
+    }
+    return value;
+  };
+
+  const edges: Edge[] = [];
+  for (const candidate of candidates) {
+    const rootA = find(candidate.a);
+    const rootB = find(candidate.b);
+    if (rootA === rootB) continue;
+    parent[rootA] = rootB;
+    edges.push({ from: nodes[candidate.a], to: nodes[candidate.b] });
+    if (edges.length === nodes.length - 1) break;
+  }
+
+  return { nodes, edges };
+};
+
 export default function OpenGraphImage() {
+  const { nodes, edges } = buildMst();
+
   return new ImageResponse(
     (
       <div
@@ -12,49 +84,89 @@ export default function OpenGraphImage() {
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          padding: "80px",
+          position: "relative",
           backgroundColor: "#0f172a",
-          backgroundImage:
-            "radial-gradient(circle at 85% 15%, rgba(59,130,246,0.22), transparent 55%)",
           fontFamily: "sans-serif",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
-          <svg width="72" height="72" viewBox="0 0 32 32" fill="none">
-            <g
+        <svg
+          width={size.width}
+          height={size.height}
+          style={{ position: "absolute", top: 0, left: 0 }}
+        >
+          {edges.map((edge, index) => (
+            <line
+              key={`edge-${index}`}
+              x1={edge.from.x}
+              y1={edge.from.y}
+              x2={edge.to.x}
+              y2={edge.to.y}
               stroke="#3b82f6"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="9,8 17,16 9,24" />
-              <line x1="20" y1="24" x2="26" y2="24" />
-            </g>
-          </svg>
-          <span style={{ color: "#94a3b8", fontSize: "34px", fontWeight: 600 }}>
-            vuhnger.dev
-          </span>
-        </div>
-
-        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-          <span style={{ color: "#f8fafc", fontSize: "84px", fontWeight: 800 }}>
-            Victor Uhnger
-          </span>
-          <span style={{ color: "#cbd5e1", fontSize: "40px", fontWeight: 500 }}>
-            Masterstudent i informatikk · utvikler
-          </span>
-        </div>
+              strokeOpacity={0.5}
+              strokeWidth={2.5}
+            />
+          ))}
+          {nodes.map((node, index) => (
+            <circle
+              key={`node-${index}`}
+              cx={node.x}
+              cy={node.y}
+              r={7}
+              fill="#0f172a"
+              stroke="#3b82f6"
+              strokeOpacity={0.85}
+              strokeWidth={2}
+            />
+          ))}
+        </svg>
 
         <div
           style={{
-            height: "8px",
-            width: "220px",
-            borderRadius: "9999px",
-            backgroundColor: "#3b82f6",
+            position: "absolute",
+            top: "80px",
+            left: "80px",
+            right: "80px",
+            bottom: "80px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
           }}
-        />
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+            <svg width="72" height="72" viewBox="0 0 32 32" fill="none">
+              <g
+                stroke="#3b82f6"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="9,8 17,16 9,24" />
+                <line x1="20" y1="24" x2="26" y2="24" />
+              </g>
+            </svg>
+            <span style={{ color: "#94a3b8", fontSize: "34px", fontWeight: 600 }}>
+              vuhnger.dev
+            </span>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+            <span style={{ color: "#f8fafc", fontSize: "84px", fontWeight: 800 }}>
+              Victor Uhnger
+            </span>
+            <span style={{ color: "#cbd5e1", fontSize: "40px", fontWeight: 500 }}>
+              Master i systemarkitektur og fullstack-utvikler
+            </span>
+          </div>
+
+          <div
+            style={{
+              height: "8px",
+              width: "220px",
+              borderRadius: "9999px",
+              backgroundColor: "#3b82f6",
+            }}
+          />
+        </div>
       </div>
     ),
     size,

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -26,8 +26,15 @@ import {
   SiCss,
   SiDjango,
 } from "react-icons/si";
+import type { Metadata } from "next";
 import AutoSnakeBackground from "@/components/projects/AutoSnakeBackground";
 import AccessibleDialog from "@/components/ui/accessible-dialog";
+
+export const metadata: Metadata = {
+  title: "Prosjekter",
+  description:
+    "Et utvalg prosjekter jeg har jobbet med de siste årene - sikkerhet, API-er, KI-drevet infrastruktur og webutvikling.",
+};
 
 type Project = {
   id: string;

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://vuhnger.dev";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://vuhnger.dev";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  const routes = ["", "/projects", "/cv", "/master", "/mst"];
+
+  return routes.map((route) => ({
+    url: `${BASE_URL}${route}`,
+    lastModified,
+    changeFrequency: "monthly",
+    priority: route === "" ? 1 : 0.7,
+  }));
+}

--- a/components/home/BentoGrid.tsx
+++ b/components/home/BentoGrid.tsx
@@ -8,7 +8,6 @@ import { Suspense } from "react";
 import MasterCountdown from "./MasterCountdown";
 import { StatsCardsLoading } from "./StatsCards";
 import PrefetchedStatsCards from "./PrefetchedStatsCards";
-import { Space } from "lucide-react";
 
 const BentoGrid = () => {
   const clickableOutline = '2px solid var(--ds-color-accent-base-default)';

--- a/components/master/MasterProgress.tsx
+++ b/components/master/MasterProgress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Heading, Paragraph } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
 
 type MasterProgressProps = {
   start: string;


### PR DESCRIPTION
Startet som litt SEO-arbeid og vokste til en større runde med opprydning og refaktor av frontenden.

**SEO og deling**
- Per-side metadata (egne titler + beskrivelser på cv/projects/master/mst)
- OG-bilde generert med `next/og`, nå med et ekte minimum spanning tree som kunst
- sitemap.xml + robots.txt, `metadataBase` = https://vuhnger.dev

**Robusthet**
- `app/error.tsx` error boundary med "prøv igjen"

**Opprydning**
- Slettet død kode: `Hero`, `StatsOverview`, `SnowfallClient`
- Fjernet ubrukt `react-snowfall`-dependency
- Ryddet to gamle ESLint-warnings

**Gjenbruk og lesbarhet**
- Trakk ut `lib/mst.ts` (union-find + Kruskal) med tester – brukes nå av både MST-bakgrunnen og OG-bildet i stedet for duplisert kode
- Tester for parsing/transformasjon i `services/api/stats.ts`
- Delte opp de to største komponentene: `AStarVisualization` (423 → 210 linjer) og `MstVisualization` (472 → 305) i separerte biter for scene/settings/colors/render, med en delt `useVisualizationEnvironment`-hook

Begge visualiseringene og OG-bildet er sjekket i browseren og oppfører seg som før.