### PR TITLE
fix: strava activities-limit innenfor API-taket (200)

### DIFF
--- a/services/api/stats.test.ts
+++ b/services/api/stats.test.ts
@@ -71,6 +71,35 @@ describe("fetchRunningActivities", () => {
     // API-et svarer 422 på limit over 200, så vi må holde oss innenfor.
     expect(Number(url.searchParams.get("limit"))).toBeLessThanOrEqual(200);
   });
+
+  it("paginates with offset and merges every page", async () => {
+    const fullPage = {
+      total: 250,
+      data: Array.from({ length: 200 }, () => ({ distance: 1000 })),
+    };
+    const lastPage = {
+      total: 250,
+      data: Array.from({ length: 50 }, () => ({ distance: 2000 })),
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => fullPage })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => lastPage });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRunningActivities(2026);
+
+    expect(result).toHaveLength(250);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("offset=0");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("offset=200");
+  });
+
+  it("stops after a single page when the year has few activities", async () => {
+    const fetchMock = mockFetch({ total: 2, data: [{ distance: 1 }, { distance: 2 }] });
+    await fetchRunningActivities(2026);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("fetchCodingStats", () => {

--- a/services/api/stats.test.ts
+++ b/services/api/stats.test.ts
@@ -61,6 +61,16 @@ describe("fetchRunningActivities", () => {
     mockFetch({ data: [{ distance: -1 }] });
     await expect(fetchRunningActivities(2026)).rejects.toThrow();
   });
+
+  it("requests the given year within the API's limit cap", async () => {
+    const fetchMock = mockFetch({ data: [] });
+    await fetchRunningActivities(2026);
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(url.searchParams.get("year")).toBe("2026");
+    // API-et svarer 422 på limit over 200, så vi må holde oss innenfor.
+    expect(Number(url.searchParams.get("limit"))).toBeLessThanOrEqual(200);
+  });
 });
 
 describe("fetchCodingStats", () => {

--- a/services/api/stats.ts
+++ b/services/api/stats.ts
@@ -8,6 +8,7 @@ const stravaYtdSchema = z.object({
 });
 
 const stravaActivitiesSchema = z.object({
+  total: z.number().nonnegative().optional(),
   data: z.array(
     z.object({
       distance: z.number().nonnegative(),
@@ -43,23 +44,36 @@ export async function fetchRunningDistance(signal?: AbortSignal): Promise<number
   return response.data.run?.distance;
 }
 
-// API-et avviser limit over 200 (HTTP 422). 200 dekker et helt års løpeturer.
-const ACTIVITIES_LIMIT = 200;
+// API-et avviser limit over 200 (HTTP 422), så vi henter én side av gangen.
+const ACTIVITIES_PAGE_SIZE = 200;
+// Sikkerhetsgrense mot uendelig løkke (opptil 4000 turer på ett år).
+const ACTIVITIES_MAX_PAGES = 20;
 
 export async function fetchRunningActivities(
   year: number,
   signal?: AbortSignal,
 ): Promise<RunningActivity[]> {
-  const response = await fetchApi(
-    `/strava/activities?year=${year}&activity_type=Run&limit=${ACTIVITIES_LIMIT}`,
-    stravaActivitiesSchema,
-    signal,
-  );
+  const activities: RunningActivity[] = [];
 
-  return response.data.map((activity) => ({
-    distance: activity.distance,
-    movingTime: activity.moving_time,
-  }));
+  for (let page = 0; page < ACTIVITIES_MAX_PAGES; page += 1) {
+    const offset = page * ACTIVITIES_PAGE_SIZE;
+    const response = await fetchApi(
+      `/strava/activities?year=${year}&activity_type=Run&limit=${ACTIVITIES_PAGE_SIZE}&offset=${offset}`,
+      stravaActivitiesSchema,
+      signal,
+    );
+
+    for (const activity of response.data) {
+      activities.push({ distance: activity.distance, movingTime: activity.moving_time });
+    }
+
+    // Kortere side enn sidestørrelsen (eller vi har nådd total) = siste side.
+    const reachedTotal =
+      response.total !== undefined && offset + response.data.length >= response.total;
+    if (response.data.length < ACTIVITIES_PAGE_SIZE || reachedTotal) break;
+  }
+
+  return activities;
 }
 
 export async function fetchCodingStats(signal?: AbortSignal): Promise<CodingStats> {

--- a/services/api/stats.ts
+++ b/services/api/stats.ts
@@ -43,12 +43,15 @@ export async function fetchRunningDistance(signal?: AbortSignal): Promise<number
   return response.data.run?.distance;
 }
 
+// API-et avviser limit over 200 (HTTP 422). 200 dekker et helt års løpeturer.
+const ACTIVITIES_LIMIT = 200;
+
 export async function fetchRunningActivities(
   year: number,
   signal?: AbortSignal,
 ): Promise<RunningActivity[]> {
   const response = await fetchApi(
-    `/strava/activities?year=${year}&activity_type=Run&limit=500`,
+    `/strava/activities?year=${year}&activity_type=Run&limit=${ACTIVITIES_LIMIT}`,
     stravaActivitiesSchema,
     signal,
   );


### PR DESCRIPTION
Løpeaktivitetene (topp-3 på forsiden) forsvant fordi API-et nå avviser `limit` over 200.

Feilsøking mot https://api.vuhnger.dev/strava:
- `/strava/health` og `/strava/stats/ytd` → 200 OK (derfor viste "1 020 km" fortsatt)
- `/strava/activities?...&limit=500` → **HTTP 422** (`Input should be less than or equal to 200`)
- `...&limit=200` → 200 OK, `total: 106` turer

Så det var verken feil rute eller manglende data – bare en for høy `limit`. Senker 500 → 200 (rikelig for et års turer) og legger til en test som feiler hvis limit igjen overstiger 200.

Verifisert i browseren: topp-3-lista er tilbake på forsiden.