### PR TITLE
feat: registrer sidebesøk (fire-and-forget beacon)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
+import VisitTracker from "@/components/layout/VisitTracker";
 import { Analytics } from "@vercel/analytics/next";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
 
@@ -65,6 +66,7 @@ export default function RootLayout({
           {children}
           <Footer />
         </ReactQueryProvider>
+        <VisitTracker />
         <Analytics />
       </body>
     </html>

--- a/components/layout/VisitTracker.tsx
+++ b/components/layout/VisitTracker.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+import { recordVisit } from "@/services/api/analytics";
+
+/**
+ * Registrerer et sidebesøk ved første last og ved hver klient-navigering.
+ * Rendrer ingenting.
+ */
+const VisitTracker = () => {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    recordVisit(pathname, document.referrer);
+  }, [pathname]);
+
+  return null;
+};
+
+export default VisitTracker;

--- a/services/api/analytics.ts
+++ b/services/api/analytics.ts
@@ -1,0 +1,15 @@
+import { API_BASE_URL } from "./client";
+
+/**
+ * Sender en fire-and-forget besøksnotis til API-et. Feiler stille og blokkerer
+ * aldri sidevisningen. `keepalive` lar requesten fullføre selv om brukeren
+ * navigerer bort med en gang.
+ */
+export function recordVisit(path: string, referrer: string): void {
+  void fetch(`${API_BASE_URL}/site/visit`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ path, referrer }),
+    keepalive: true,
+  }).catch(() => {});
+}

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const API_BASE_URL = "https://api.vuhnger.dev";
+export const API_BASE_URL = "https://api.vuhnger.dev";
 const API_REVALIDATE_SECONDS = 5 * 60;
 const API_TIMEOUT_MS = 5_000;
 


### PR DESCRIPTION
Legger til besøksregistrering slik du ba om.

- `VisitTracker` (client-komponent i layouten) sender `POST /site/visit` med `{ path, referrer }`
- Fyrer ved første sidelast **og** ved hver klient-navigering (`usePathname`), så SPA-navigering også telles
- Fetch-en ligger i `services/api/analytics.ts` (ikke inline i layout, per repo-konvensjonen) og gjenbruker `API_BASE_URL`
- Fire-and-forget med `keepalive` + `.catch(() => {})` – feiler stille, blokkerer aldri sidevisningen

**NB om API-et:** endepunktet `/site/visit` svarer akkurat nå 502/503 og ligger ikke i openapi, så det registreres ingenting server-side ennå. Beaconen fyrer riktig (verifisert i browser-nettverksloggen), og begynner å registrere så snart endepunktet er oppe – ingen frontend-endring trengs da.