### PR TITLE
feat: myke sideoverganger (View Transitions)

### DIFF
--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -1,4 +1,4 @@
-import NextLink from "next/link";
+import { Link as NextLink } from "next-view-transitions";
 import Image from "next/image";
 import { Card, Heading, Link, Paragraph } from "@digdir/designsystemet-react";
 import { FaGithub, FaLinkedinIn } from "react-icons/fa";

--- a/app/globals.css
+++ b/app/globals.css
@@ -223,3 +223,19 @@
     var(--ds-shadow-xl),
     inset 0 0 80px color-mix(in srgb, var(--ds-color-neutral-background-default) 60%, transparent) !important;
 }
+
+/* Sideoverganger (View Transitions): en subtil cross-fade ... */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.25s;
+  animation-timing-function: ease;
+}
+
+/* ... men stopp all overgangsanimasjon ved prefers-reduced-motion. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ViewTransitions } from "next-view-transitions";
 import "./globals.css";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
@@ -50,6 +51,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
+    <ViewTransitions>
     <html lang="no" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
@@ -76,5 +78,6 @@ export default function RootLayout({
         />
       </body>
     </html>
+    </ViewTransitions>
   );
 }

--- a/components/home/BentoGrid.tsx
+++ b/components/home/BentoGrid.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import NextLink from "next/link";
+import { Link as NextLink } from "next-view-transitions";
 import { Card, Heading, Paragraph, Link } from "@digdir/designsystemet-react";
 import { AiFillGithub } from "react-icons/ai";
 import { FaLinkedinIn, FaStrava } from "react-icons/fa";

--- a/components/home/MasterCountdown.tsx
+++ b/components/home/MasterCountdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import NextLink from "next/link";
+import { Link as NextLink } from "next-view-transitions";
 import { Card, Paragraph } from "@digdir/designsystemet-react";
 import { calculateMasterProgress, MASTER_TIMELINE } from "@/lib/master";
 

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import NextLink from "next/link";
+import { Link as NextLink } from "next-view-transitions";
 import { House } from "lucide-react";
 import { Suspense } from "react";
 import BackgroundVisualizationToggle from "./BackgroundVisualizationToggle";

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.26.0",
     "next": "16.2.11",
+    "next-view-transitions": "^0.3.5",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-icons": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next-view-transitions:
+        specifier: ^0.3.5
+        version: 0.3.5(next@16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2048,6 +2051,13 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-view-transitions@0.3.5:
+    resolution: {integrity: sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg==}
+    peerDependencies:
+      next: '>=14.0.0'
+      react: '>=18.2.0 || ^19.0.0'
+      react-dom: '>=18.2.0 || ^19.0.0'
 
   next@16.2.11:
     resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
@@ -4484,6 +4494,12 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  next-view-transitions@0.3.5(next@16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      next: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   next@16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Legger til en subtil cross-fade mellom sider (Vei 1 fra praten vår).

- Wrapper root-layouten i `next-view-transitions` sin `<ViewTransitions>`
- Bytter de interne nav-lenkene (Navbar, CV/Prosjekter-kortene, master-kortet, CV-siden) til pakkens `Link` – aliaset beholdes (`NextLink`), så bruksstedene er urørt. Eksterne lenker (GitHub/LinkedIn/Strava) er ikke rørt.
- `::view-transition-old/new(root)` får 0.25s cross-fade, og en `prefers-reduced-motion`-guard stopper all overgangsanimasjon (jf. CLAUDE.md)

Faller elegant tilbake til ingen animasjon i browsere uten støtte (Firefox). Verifisert i Chrome: navigering funker via de nye lenkene, ingen feil fra pakken, build + 37 tester grønne.