### PR TITLE
fix: besøks-beaconen kan aldri kaste

### DIFF
--- a/services/api/analytics.test.ts
+++ b/services/api/analytics.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recordVisit } from "./analytics";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("recordVisit", () => {
+  it("uses sendBeacon when available", () => {
+    const sendBeacon = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("navigator", { sendBeacon });
+
+    recordVisit("/prosjekter", "https://example.com");
+
+    expect(sendBeacon).toHaveBeenCalledOnce();
+    expect(String(sendBeacon.mock.calls[0][0])).toContain("/site/visit");
+  });
+
+  it("falls back to fetch when sendBeacon is unavailable", () => {
+    vi.stubGlobal("navigator", {});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    recordVisit("/cv", "");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.keepalive).toBe(true);
+  });
+
+  it("never throws even if sendBeacon throws synchronously", () => {
+    vi.stubGlobal("navigator", {
+      sendBeacon: () => {
+        throw new TypeError("Failed to fetch");
+      },
+    });
+
+    expect(() => recordVisit("/", "")).not.toThrow();
+  });
+
+  it("never throws even if fetch throws synchronously", () => {
+    vi.stubGlobal("navigator", {});
+    vi.stubGlobal("fetch", () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    expect(() => recordVisit("/", "")).not.toThrow();
+  });
+});

--- a/services/api/analytics.ts
+++ b/services/api/analytics.ts
@@ -1,15 +1,32 @@
 import { API_BASE_URL } from "./client";
 
 /**
- * Sender en fire-and-forget besøksnotis til API-et. Feiler stille og blokkerer
- * aldri sidevisningen. `keepalive` lar requesten fullføre selv om brukeren
- * navigerer bort med en gang.
+ * Sender en fire-and-forget besøksnotis til API-et. Skal ALDRI kaste eller
+ * påvirke sidevisningen.
+ *
+ * Bruker `navigator.sendBeacon` når det finnes: det er laget nettopp for dette,
+ * fullfører selv om brukeren navigerer bort, og påvirkes ikke av kode som
+ * wrapper `window.fetch` (f.eks. nettleser-utvidelser som ellers kan få `fetch`
+ * til å kaste synkront). Faller tilbake til `fetch` med `keepalive`. Alt er
+ * pakket i try/catch fordi selv `.catch()` ikke fanger en synkron throw.
  */
 export function recordVisit(path: string, referrer: string): void {
-  void fetch(`${API_BASE_URL}/site/visit`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ path, referrer }),
-    keepalive: true,
-  }).catch(() => {});
+  const url = `${API_BASE_URL}/site/visit`;
+  const payload = JSON.stringify({ path, referrer });
+
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      navigator.sendBeacon(url, new Blob([payload], { type: "application/json" }));
+      return;
+    }
+
+    void fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // Besøksregistrering skal aldri velte siden.
+  }
 }


### PR DESCRIPTION
Fikser runtime-feilen `TypeError: Failed to fetch` fra `recordVisit`.

**Årsak:** `fetch(...)` kunne kaste **synkront** (typisk når en nettleser-utvidelse wrapper `window.fetch`). Da ble aldri `.catch()` koblet på, så feilen propagerte ut av `VisitTracker`-effekten og ble en runtime-feil / kunne trigge error-boundaryen. Fire-and-forget skal aldri kunne velte siden.

**Fiks:**
- Bruker `navigator.sendBeacon` når det finnes – laget for nettopp dette, fullfører selv om brukeren navigerer bort, og påvirkes ikke av `fetch`-wrappere
- `fetch` med `keepalive` som fallback
- Alt pakket i `try/catch` (siden `.catch()` ikke fanger en synkron throw)
- Tester som vokter at `recordVisit` aldri kaster, selv om `sendBeacon`/`fetch` kaster

Verifisert i browseren: ingen error-overlay og ingen konsoll-exception lenger etter navigering.