### PR TITLE
fix: besøks-beaconen må bruke fetch (ikke sendBeacon)

### DIFF
--- a/services/api/analytics.test.ts
+++ b/services/api/analytics.test.ts
@@ -8,45 +8,33 @@ afterEach(() => {
 });
 
 describe("recordVisit", () => {
-  it("uses sendBeacon when available", () => {
-    const sendBeacon = vi.fn().mockReturnValue(true);
-    vi.stubGlobal("navigator", { sendBeacon });
-
-    recordVisit("/prosjekter", "https://example.com");
-
-    expect(sendBeacon).toHaveBeenCalledOnce();
-    expect(String(sendBeacon.mock.calls[0][0])).toContain("/site/visit");
-  });
-
-  it("falls back to fetch when sendBeacon is unavailable", () => {
-    vi.stubGlobal("navigator", {});
+  it("posts path and referrer to the visit endpoint with keepalive", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
     vi.stubGlobal("fetch", fetchMock);
 
-    recordVisit("/cv", "");
+    recordVisit("/prosjekter", "https://example.com");
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    const [, init] = fetchMock.mock.calls[0];
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/site/visit");
     expect(init.method).toBe("POST");
     expect(init.keepalive).toBe(true);
+    expect(init.headers).toMatchObject({ "content-type": "application/json" });
+    expect(JSON.parse(init.body)).toEqual({
+      path: "/prosjekter",
+      referrer: "https://example.com",
+    });
   });
 
-  it("never throws even if sendBeacon throws synchronously", () => {
-    vi.stubGlobal("navigator", {
-      sendBeacon: () => {
-        throw new TypeError("Failed to fetch");
-      },
-    });
-
+  it("never throws when fetch rejects asynchronously", () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
     expect(() => recordVisit("/", "")).not.toThrow();
   });
 
-  it("never throws even if fetch throws synchronously", () => {
-    vi.stubGlobal("navigator", {});
+  it("never throws when fetch throws synchronously", () => {
     vi.stubGlobal("fetch", () => {
       throw new TypeError("Failed to fetch");
     });
-
     expect(() => recordVisit("/", "")).not.toThrow();
   });
 });

--- a/services/api/analytics.ts
+++ b/services/api/analytics.ts
@@ -1,29 +1,23 @@
 import { API_BASE_URL } from "./client";
 
 /**
- * Sender en fire-and-forget besøksnotis til API-et. Skal ALDRI kaste eller
- * påvirke sidevisningen.
+ * Fire-and-forget besøksnotis. Skal ALDRI kaste eller påvirke sidevisningen.
  *
- * Bruker `navigator.sendBeacon` når det finnes: det er laget nettopp for dette,
- * fullfører selv om brukeren navigerer bort, og påvirkes ikke av kode som
- * wrapper `window.fetch` (f.eks. nettleser-utvidelser som ellers kan få `fetch`
- * til å kaste synkront). Faller tilbake til `fetch` med `keepalive`. Alt er
- * pakket i try/catch fordi selv `.catch()` ikke fanger en synkron throw.
+ * Bruker `fetch` (ikke `sendBeacon`): endepunktet er cross-origin og krever
+ * `Content-Type: application/json`, som utløser en CORS-preflight. `fetch`
+ * håndterer preflighten (backend svarer på `OPTIONS`), mens `sendBeacon` ikke
+ * kan preflighte og derfor ikke ville levere. `keepalive` lar kallet fullføre
+ * selv om brukeren navigerer bort med en gang.
+ *
+ * `.catch` tar async-avvisning; `try/catch` tar en synkron throw (kan skje når
+ * en nettleser-utvidelse wrapper `window.fetch`), som `.catch` alene ikke fanger.
  */
 export function recordVisit(path: string, referrer: string): void {
-  const url = `${API_BASE_URL}/site/visit`;
-  const payload = JSON.stringify({ path, referrer });
-
   try {
-    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
-      navigator.sendBeacon(url, new Blob([payload], { type: "application/json" }));
-      return;
-    }
-
-    void fetch(url, {
+    void fetch(`${API_BASE_URL}/site/visit`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: payload,
+      body: JSON.stringify({ path, referrer }),
       keepalive: true,
     }).catch(() => {});
   } catch {


### PR DESCRIPTION
Retter transporten i `recordVisit`.

**Bakgrunn:** #118 implementerte beaconen, #122 hardnet den mot en synkron throw ved å bytte til `navigator.sendBeacon`. Men det bytten bryter cross-origin-leveringen: endepunktet krever `Content-Type: application/json`, som utløser en CORS-preflight — og `sendBeacon` kan ikke preflighte. Backend har åpnet CORS for en `fetch`-preflight (verifisert: `OPTIONS https://api.vuhnger.dev/site/visit` fra origin `https://vuhnger.dev` → 200 med riktige `access-control-*`-headere).

**Fiks:** tilbake til `fetch` + `keepalive` (matcher kontrakten og din spec), men beholder `try/catch` + `.catch` fra #122 så beaconen fortsatt aldri kaster (heller ikke ved en utvidelse som wrapper `window.fetch`).

Verifisert lokalt: endepunkt POST → 200, CORS-preflight OK, tester + build grønt. Selve cross-origin-leveringen kan først bekreftes på prod (CORS er kun åpnet for `vuhnger.dev`, ikke localhost/preview).