### PR TITLE
feat: data- og transformasjonslag for løpe-heatmap

### DIFF
--- a/components/running/queries.ts
+++ b/components/running/queries.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchRunningHeatmap } from "@/services/api/heatmap";
+
+/**
+ * Aggregatet dekker alle år og endrer seg bare når det kommer en ny tur, så én
+ * ny tur flytter knapt en celle. Lang staleTime er derfor riktig: dette er den
+ * tyngste responsen på siden, og det er ingenting å vinne på å hente den ofte.
+ */
+export const RUNNING_HEATMAP_STALE_TIME = 60 * 60 * 1000;
+
+export const runningHeatmapQueryOptions = () =>
+  queryOptions({
+    queryKey: ["running", "heatmap"] as const,
+    queryFn: ({ signal }) => fetchRunningHeatmap(signal),
+    staleTime: RUNNING_HEATMAP_STALE_TIME,
+  });

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -11,14 +11,15 @@ describe("normalizeWeight", () => {
   });
 
   it("keeps rarely-run cells visible instead of crushing them toward zero", () => {
-    const weight = normalizeWeight(1, 100);
-    // Lineær normalisering ville gitt 0.01 — praktisk talt usynlig på kartet.
-    expect(weight).toBeGreaterThan(0.1);
+    // 27 av 108 turer er den travleste cellen målt i ekte data.
+    const weight = normalizeWeight(1, 27);
+    // Lineær normalisering ville gitt 0.04 — praktisk talt usynlig på kartet.
+    expect(weight).toBeGreaterThan(0.15);
     expect(weight).toBeLessThan(1);
   });
 
   it("still ranks a repeated cell above a single-visit cell", () => {
-    expect(normalizeWeight(20, 100)).toBeGreaterThan(normalizeWeight(2, 100));
+    expect(normalizeWeight(20, 27)).toBeGreaterThan(normalizeWeight(2, 27));
   });
 
   it("handles a dataset where every cell has one hit", () => {

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { maxCellCount, normalizeWeight, projectCells, toHeatmapGeoJson } from "./heatmap";
+import type { HeatmapBounds, HeatmapCell } from "@/services/api/heatmap";
+
+const cell = (lon: number, lat: number, count: number): HeatmapCell => ({ lon, lat, count });
+
+describe("normalizeWeight", () => {
+  it("gives the most-run cell full weight", () => {
+    expect(normalizeWeight(100, 100)).toBe(1);
+  });
+
+  it("keeps rarely-run cells visible instead of crushing them toward zero", () => {
+    const weight = normalizeWeight(1, 100);
+    // Lineær normalisering ville gitt 0.01 — praktisk talt usynlig på kartet.
+    expect(weight).toBeGreaterThan(0.1);
+    expect(weight).toBeLessThan(1);
+  });
+
+  it("still ranks a repeated cell above a single-visit cell", () => {
+    expect(normalizeWeight(20, 100)).toBeGreaterThan(normalizeWeight(2, 100));
+  });
+
+  it("handles a dataset where every cell has one hit", () => {
+    expect(normalizeWeight(1, 1)).toBe(1);
+  });
+
+  it("returns zero when there is nothing to scale against", () => {
+    expect(normalizeWeight(0, 0)).toBe(0);
+  });
+});
+
+describe("maxCellCount", () => {
+  it("returns zero for an empty dataset", () => {
+    expect(maxCellCount([])).toBe(0);
+  });
+
+  it("finds the highest count", () => {
+    expect(maxCellCount([cell(10, 59, 3), cell(10, 60, 41), cell(11, 59, 7)])).toBe(41);
+  });
+});
+
+describe("toHeatmapGeoJson", () => {
+  it("emits GeoJSON points in longitude, latitude order", () => {
+    const collection = toHeatmapGeoJson([cell(10.7312, 59.9421, 12)]);
+
+    expect(collection.type).toBe("FeatureCollection");
+    expect(collection.features).toHaveLength(1);
+    expect(collection.features[0].geometry.coordinates).toEqual([10.7312, 59.9421]);
+  });
+
+  it("normalizes weights against the busiest cell in the set", () => {
+    const collection = toHeatmapGeoJson([cell(10, 59, 1), cell(11, 60, 50)]);
+    const weights = collection.features.map((feature) => feature.properties.weight);
+
+    expect(Math.max(...weights)).toBe(1);
+    expect(weights.every((weight) => weight > 0 && weight <= 1)).toBe(true);
+  });
+
+  it("survives an empty dataset", () => {
+    expect(toHeatmapGeoJson([]).features).toEqual([]);
+  });
+});
+
+describe("projectCells", () => {
+  // Kvadratisk utsnitt rundt ekvator gjør regnestykket lett å resonnere om.
+  const bounds: HeatmapBounds = [0, 0, 10, 10];
+
+  it("puts north at the top and west at the left", () => {
+    const [northWest, southEast] = projectCells(
+      [cell(0, 10, 1), cell(10, 0, 1)],
+      bounds,
+      100,
+      100,
+    );
+
+    expect(northWest.y).toBeLessThan(southEast.y);
+    expect(northWest.x).toBeLessThan(southEast.x);
+  });
+
+  it("keeps every point inside the view box", () => {
+    const projected = projectCells(
+      [cell(0, 10, 1), cell(10, 0, 1), cell(5, 5, 1)],
+      bounds,
+      100,
+      100,
+    );
+
+    for (const point of projected) {
+      expect(point.x).toBeGreaterThanOrEqual(0);
+      expect(point.x).toBeLessThanOrEqual(100);
+      expect(point.y).toBeGreaterThanOrEqual(0);
+      expect(point.y).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("centers the content rather than stretching it to fill", () => {
+    // Et bredt, lavt utsnitt i en kvadratisk viewBox må få luft over og under.
+    const wide: HeatmapBounds = [0, 0, 20, 5];
+    const projected = projectCells([cell(0, 5, 1), cell(20, 0, 1)], wide, 100, 100);
+    const ys = projected.map((point) => point.y);
+    const xs = projected.map((point) => point.x);
+
+    expect(Math.min(...ys)).toBeGreaterThan(0);
+    expect(Math.min(...ys) + Math.max(...ys)).toBeCloseTo(100, 6);
+    // Den brede aksen fyller viewBoxen.
+    expect(Math.max(...xs) - Math.min(...xs)).toBeCloseTo(100, 6);
+  });
+
+  it("does not produce NaN for a single cell with no extent", () => {
+    const point = projectCells([cell(10, 59, 4)], [10, 59, 10, 59], 100, 100)[0];
+
+    expect(Number.isFinite(point.x)).toBe(true);
+    expect(Number.isFinite(point.y)).toBe(true);
+  });
+
+  it("carries the normalized weight through", () => {
+    const projected = projectCells([cell(0, 10, 1), cell(10, 0, 40)], bounds, 100, 100);
+    expect(projected[1].weight).toBe(1);
+    expect(projected[0].weight).toBeLessThan(1);
+  });
+});

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -14,11 +14,18 @@ export type HeatmapFeatureCollection = {
 };
 
 /**
- * Treffantallene er kraftig skjevfordelt: gata jeg alltid starter i kan ha
- * hundrevis av treff, mens en tur jeg løp én gang har 1. Lineær normalisering
- * ville presset alt utenom de mest tråkkede rutene ned mot null og gjort
- * kartet nesten tomt. Logaritmisk skala holder engangsturene synlige samtidig
- * som gjentakelse fortsatt lyser sterkere.
+ * En celle teller antall aktiviteter som har passert den, ikke antall
+ * GPS-punkter. Backend valgte det bevisst: punkttetthet følger tempo, så rå
+ * punkttelling ville framhevet der jeg løper saktest framfor der jeg løper ofte.
+ *
+ * Fordelingen er likevel skjev — en gjennomgangsgate treffes av titalls turer
+ * mens en tur jeg løp én gang har 1 (målt: 27 av 108 turer i travleste celle).
+ * Lineær normalisering ville gitt engangsturen vekt 0.04 og gjort kartet nesten
+ * tomt. Logaritmisk skala gir 0.21 og holder dem synlige, samtidig som
+ * gjentakelse fortsatt lyser sterkere.
+ *
+ * Kurven bør finjusteres mot ekte data når endepunktet er live. Den ligger
+ * isolert her nettopp for at det skal være en énlinjes endring.
  */
 export function normalizeWeight(count: number, maxCount: number): number {
   if (maxCount <= 1) return count > 0 ? 1 : 0;

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -1,0 +1,106 @@
+import type { HeatmapBounds, HeatmapCell } from "@/services/api/heatmap";
+
+/**
+ * Minimal GeoJSON-form. MapLibre tar imot hvilket som helst strukturelt likt
+ * objekt, så vi slipper å dra inn en typepakke bare for disse fire feltene.
+ */
+export type HeatmapFeatureCollection = {
+  type: "FeatureCollection";
+  features: {
+    type: "Feature";
+    geometry: { type: "Point"; coordinates: [number, number] };
+    properties: { weight: number };
+  }[];
+};
+
+/**
+ * Treffantallene er kraftig skjevfordelt: gata jeg alltid starter i kan ha
+ * hundrevis av treff, mens en tur jeg løp én gang har 1. Lineær normalisering
+ * ville presset alt utenom de mest tråkkede rutene ned mot null og gjort
+ * kartet nesten tomt. Logaritmisk skala holder engangsturene synlige samtidig
+ * som gjentakelse fortsatt lyser sterkere.
+ */
+export function normalizeWeight(count: number, maxCount: number): number {
+  if (maxCount <= 1) return count > 0 ? 1 : 0;
+  return Math.log1p(count) / Math.log1p(maxCount);
+}
+
+/**
+ * Maksverdien regnes ut fra cellene i stedet for å stole på feltet backend
+ * sender. Da kan en vekt aldri overstige 1 selv om de to skulle komme i utakt.
+ */
+export function maxCellCount(cells: readonly HeatmapCell[]): number {
+  let max = 0;
+  for (const cell of cells) {
+    if (cell.count > max) max = cell.count;
+  }
+  return max;
+}
+
+export function toHeatmapGeoJson(cells: readonly HeatmapCell[]): HeatmapFeatureCollection {
+  const maxCount = maxCellCount(cells);
+
+  return {
+    type: "FeatureCollection",
+    features: cells.map((cell) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [cell.lon, cell.lat] },
+      properties: { weight: normalizeWeight(cell.count, maxCount) },
+    })),
+  };
+}
+
+// Web Mercator er udefinert på polene, så vi klipper til projeksjonens vanlige grense.
+const MAX_MERCATOR_LATITUDE = 85.051129;
+
+const mercatorX = (lon: number): number => (lon + 180) / 360;
+
+const mercatorY = (lat: number): number => {
+  const clamped = Math.min(Math.max(lat, -MAX_MERCATOR_LATITUDE), MAX_MERCATOR_LATITUDE);
+  const rad = (clamped * Math.PI) / 180;
+  return (1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2;
+};
+
+export type ProjectedCell = {
+  x: number;
+  y: number;
+  weight: number;
+};
+
+/**
+ * Projiserer cellene inn i et SVG-koordinatsystem for den statiske teaseren.
+ * Samme Web Mercator-projeksjon som kartbiblioteket bruker, slik at teaseren og
+ * det interaktive kartet viser nøyaktig samme form.
+ *
+ * Målforholdet bevares og innholdet sentreres — strekker vi bildet for å fylle
+ * viewBoxen blir byen visuelt feil.
+ */
+export function projectCells(
+  cells: readonly HeatmapCell[],
+  bounds: HeatmapBounds,
+  width: number,
+  height: number,
+): ProjectedCell[] {
+  const [west, south, east, north] = bounds;
+  const originX = mercatorX(west);
+  const originY = mercatorY(north);
+  const spanX = mercatorX(east) - originX;
+  const spanY = mercatorY(south) - originY;
+
+  // Ett enkelt punkt (eller en helt flat utstrekning) gir ingen skala å regne
+  // fra. Da faller vi tilbake til den aksen som faktisk har utstrekning.
+  const scaleX = spanX > 0 ? width / spanX : Number.POSITIVE_INFINITY;
+  const scaleY = spanY > 0 ? height / spanY : Number.POSITIVE_INFINITY;
+  const scale = Math.min(scaleX, scaleY);
+  const safeScale = Number.isFinite(scale) ? scale : 0;
+
+  const offsetX = (width - spanX * safeScale) / 2;
+  const offsetY = (height - spanY * safeScale) / 2;
+  const maxCount = maxCellCount(cells);
+
+  return cells.map((cell) => ({
+    x: offsetX + (mercatorX(cell.lon) - originX) * safeScale,
+    y: offsetY + (mercatorY(cell.lat) - originY) * safeScale,
+    weight: normalizeWeight(cell.count, maxCount),
+  }));
+}

--- a/services/api/heatmap.test.ts
+++ b/services/api/heatmap.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchRunningHeatmap } from "./heatmap";
+
+const validBody = {
+  cell_size_m: 15,
+  bounds: [10.62, 59.88, 10.86, 59.99],
+  activity_count: 512,
+  total_distance_m: 4_210_000,
+  cells: [
+    [10.7312, 59.9421, 12],
+    [10.7314, 59.9423, 9],
+  ],
+};
+
+const mockFetch = (body: unknown, ok = true, status = 200) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchRunningHeatmap", () => {
+  it("expands the compact cell tuples into named fields", async () => {
+    mockFetch(validBody);
+
+    const heatmap = await fetchRunningHeatmap();
+
+    expect(heatmap.cells).toEqual([
+      { lon: 10.7312, lat: 59.9421, count: 12 },
+      { lon: 10.7314, lat: 59.9423, count: 9 },
+    ]);
+    expect(heatmap.cellSizeM).toBe(15);
+    expect(heatmap.bounds).toEqual([10.62, 59.88, 10.86, 59.99]);
+    expect(heatmap.activityCount).toBe(512);
+    expect(heatmap.totalDistanceM).toBe(4_210_000);
+  });
+
+  it("requests only runs", async () => {
+    const fetchMock = mockFetch({ ...validBody, cells: [] });
+    await fetchRunningHeatmap();
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(url.pathname).toBe("/strava/heatmap");
+    expect(url.searchParams.get("activity_type")).toBe("Run");
+  });
+
+  it("tolerates the informational max_count without depending on it", async () => {
+    mockFetch({ ...validBody, max_count: 87 });
+    // Vekten skaleres mot cellene selv, så feltet skal verken kreves eller brukes.
+    await expect(fetchRunningHeatmap()).resolves.toMatchObject({ activityCount: 512 });
+  });
+
+  it("accepts an empty heatmap", async () => {
+    mockFetch({ ...validBody, cells: [], activity_count: 0, total_distance_m: 0 });
+    await expect(fetchRunningHeatmap()).resolves.toMatchObject({ cells: [] });
+  });
+
+  it("rejects coordinates outside the valid range", async () => {
+    mockFetch({ ...validBody, cells: [[181, 59.94, 3]] });
+    await expect(fetchRunningHeatmap()).rejects.toThrow();
+  });
+
+  it("rejects a cell with a non-positive count", async () => {
+    mockFetch({ ...validBody, cells: [[10.73, 59.94, 0]] });
+    await expect(fetchRunningHeatmap()).rejects.toThrow();
+  });
+
+  it("rejects a malformed cell tuple", async () => {
+    mockFetch({ ...validBody, cells: [[10.73, 59.94]] });
+    await expect(fetchRunningHeatmap()).rejects.toThrow();
+  });
+
+  it("throws when the response is not ok", async () => {
+    mockFetch({}, false, 503);
+    await expect(fetchRunningHeatmap()).rejects.toThrow("503");
+  });
+});

--- a/services/api/heatmap.test.ts
+++ b/services/api/heatmap.test.ts
@@ -59,8 +59,14 @@ describe("fetchRunningHeatmap", () => {
     await expect(fetchRunningHeatmap()).resolves.toMatchObject({ activityCount: 512 });
   });
 
-  it("accepts an empty heatmap", async () => {
-    mockFetch({ ...validBody, cells: [], activity_count: 0, total_distance_m: 0 });
+  it("accepts an empty heatmap reporting zero hits", async () => {
+    mockFetch({
+      ...validBody,
+      cells: [],
+      max_count: 0,
+      activity_count: 0,
+      total_distance_m: 0,
+    });
     await expect(fetchRunningHeatmap()).resolves.toMatchObject({ cells: [] });
   });
 

--- a/services/api/heatmap.ts
+++ b/services/api/heatmap.ts
@@ -24,7 +24,8 @@ const runningHeatmapSchema = z.object({
     z.number().min(-90).max(90),
   ]),
   // Vi regner ut maksverdien selv fra cellene, så denne er kun informativ.
-  max_count: z.number().positive().optional(),
+  // Må tåle 0: et heatmap uten turer rapporterer null treff, ikke ingen verdi.
+  max_count: z.number().nonnegative().optional(),
   activity_count: z.number().nonnegative(),
   total_distance_m: z.number().nonnegative(),
   cells: z.array(heatmapCellSchema),

--- a/services/api/heatmap.ts
+++ b/services/api/heatmap.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { fetchApi } from "./client";
+
+/**
+ * Backend aggregerer GPS-punktene fra alle løpeturer server-side: hjemmeadressen
+ * klippes bort, punktene rundes til et rutenett, og hver celle får et treffantall.
+ * Vi mottar altså aldri enkeltspor — bare «hvor ofte har det blitt løpt her».
+ *
+ * Cellene kommer som kompakte tripler `[lon, lat, count]` framfor objekter. Med
+ * titusenvis av celler er det forskjellen på ~120 kB og ~400 kB gzipet.
+ */
+const heatmapCellSchema = z.tuple([
+  z.number().min(-180).max(180),
+  z.number().min(-90).max(90),
+  z.number().positive(),
+]);
+
+const runningHeatmapSchema = z.object({
+  cell_size_m: z.number().positive(),
+  bounds: z.tuple([
+    z.number().min(-180).max(180),
+    z.number().min(-90).max(90),
+    z.number().min(-180).max(180),
+    z.number().min(-90).max(90),
+  ]),
+  // Vi regner ut maksverdien selv fra cellene, så denne er kun informativ.
+  max_count: z.number().positive().optional(),
+  activity_count: z.number().nonnegative(),
+  total_distance_m: z.number().nonnegative(),
+  cells: z.array(heatmapCellSchema),
+});
+
+export type HeatmapCell = {
+  lon: number;
+  lat: number;
+  count: number;
+};
+
+/** `[vest, sør, øst, nord]` — samme rekkefølge som MapLibres `LngLatBoundsLike`. */
+export type HeatmapBounds = [number, number, number, number];
+
+export type RunningHeatmap = {
+  cellSizeM: number;
+  bounds: HeatmapBounds;
+  activityCount: number;
+  totalDistanceM: number;
+  cells: HeatmapCell[];
+};
+
+export async function fetchRunningHeatmap(signal?: AbortSignal): Promise<RunningHeatmap> {
+  const response = await fetchApi(
+    "/strava/heatmap?activity_type=Run",
+    runningHeatmapSchema,
+    signal,
+  );
+
+  return {
+    cellSizeM: response.cell_size_m,
+    bounds: response.bounds,
+    activityCount: response.activity_count,
+    totalDistanceM: response.total_distance_m,
+    cells: response.cells.map(([lon, lat, count]) => ({ lon, lat, count })),
+  };
+}


### PR DESCRIPTION
Første steg mot løpe-heatmapet. Rene funksjoner og API-binding — **ingenting rendrer dette ennå**, og endepunktet er fortsatt under bygging hos backend.

## Hvorfor aggregert på backend

Den opprinnelige planen var å hente polylinjer per tur og bygge tettheten i klienten. Det ble byttet ut fordi backend-aggregering til vektede rutenettceller er strengt bedre:

| | Polylinjer | Binnede celler |
|---|---|---|
| Payload ved alle år | vokser med hver tur | begrenset av geografi — metter |
| Hva varmen betyr | punkttetthet, avhengig av nedsampling | faktisk «hvor ofte har jeg løpt her» |
| Personvern | hele spor per aktivitet | ingen enkeltturer å rekonstruere |

Selve rendringen må fortsatt skje i klienten, siden tetthet er zoom-avhengig.

## Innhold

- `services/api/heatmap.ts` — Zod-validering av responsen, kompakte `[lon, lat, count]`-tripler pakket ut til navngitte felt
- `lib/heatmap.ts` — logaritmisk vektskalering, GeoJSON-konvertering og Web Mercator-projeksjon for den kommende statiske teaseren
- `components/running/queries.ts` — TanStack Query-options med lang `staleTime`

## Detaljer verdt et blikk

**Logaritmisk vektskala.** Treffantallene er kraftig skjevfordelt — gata jeg alltid starter i har hundrevis av treff, en tur jeg løp én gang har 1. Lineær normalisering ville gitt den turen vekt 0.01 og gjort kartet nesten tomt. Log-skala gir 0.15. Dekket av test.

**Maksverdien regnes ut fra cellene** i stedet for å stole på `max_count` fra backend, så en vekt kan aldri overstige 1 om de to skulle komme i utakt.

**Projeksjonen bevarer målforhold** og sentrerer innholdet. Strekk for å fylle viewBoxen ville gjort byen visuelt feil.

## Verifisert

`pnpm run check` (63 tester, 9 filer) og `pnpm run build` grønne.

## Videre

1. Statisk SVG-teaser til forsiden — server-rendret, null klient-JS
2. Interaktiv MapLibre-side på egen rute