### PR TITLE
Varmekart over løpeturer

### DIFF
--- a/app/running/page.tsx
+++ b/app/running/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Heading, Paragraph } from "@digdir/designsystemet-react";
+import { createQueryClient } from "@/lib/query-client";
+import RunningHeatmap from "@/components/running/RunningHeatmap";
+import { runningHeatmapQueryOptions } from "@/components/running/queries";
+
+export const metadata: Metadata = {
+  title: "Løping",
+  description:
+    "Varmekart over alle løpeturene mine, aggregert fra Strava. Jo sterkere farge, jo flere turer har gått samme vei.",
+};
+
+export default async function RunningPage() {
+  const queryClient = createQueryClient(false);
+
+  // Aggregatet er den tyngste responsen på siden. Hentes den på serveren, står
+  // kartet ferdig med data i det klientkoden tar over, framfor å vise en tom
+  // boks mens nettleseren gjør sitt eget kall.
+  await queryClient.prefetchQuery(runningHeatmapQueryOptions());
+
+  return (
+    <div
+      className="relative min-h-screen overflow-hidden pt-20 pb-16 px-4"
+      style={{ backgroundColor: "var(--ds-color-neutral-background-default)" }}
+    >
+      <div className="relative z-10 mx-auto max-w-5xl">
+        <div className="mb-6">
+          <Heading data-size="lg" style={{ marginBottom: "0.25rem" }}>
+            Løping
+          </Heading>
+          <Paragraph data-size="sm" style={{ margin: 0, color: "var(--ds-color-neutral-text-default)" }}>
+            Hver tur jeg har logget på Strava, lagt oppå hverandre. Rutene er slått sammen
+            til et rutenett på serveren, så kartet viser hvor ofte jeg har løpt et sted -
+            ikke enkeltturer.
+          </Paragraph>
+        </div>
+
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <RunningHeatmap />
+        </HydrationBoundary>
+      </div>
+    </div>
+  );
+}

--- a/app/running/page.tsx
+++ b/app/running/page.tsx
@@ -29,11 +29,6 @@ export default async function RunningPage() {
           <Heading data-size="lg" style={{ marginBottom: "0.25rem" }}>
             Løping
           </Heading>
-          <Paragraph data-size="sm" style={{ margin: 0, color: "var(--ds-color-neutral-text-default)" }}>
-            Hver tur jeg har logget på Strava, lagt oppå hverandre. Rutene er slått sammen
-            til et rutenett på serveren, så kartet viser hvor ofte jeg har løpt et sted -
-            ikke enkeltturer.
-          </Paragraph>
         </div>
 
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/app/running/page.tsx
+++ b/app/running/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
-import { Heading, Paragraph } from "@digdir/designsystemet-react";
+import { Heading } from "@digdir/designsystemet-react";
+import { isRunningHeatmapEnabled } from "@/lib/features";
 import { createQueryClient } from "@/lib/query-client";
 import RunningHeatmap from "@/components/running/RunningHeatmap";
 import { runningHeatmapQueryOptions } from "@/components/running/queries";
@@ -8,10 +10,15 @@ import { runningHeatmapQueryOptions } from "@/components/running/queries";
 export const metadata: Metadata = {
   title: "Løping",
   description:
-    "Varmekart over alle løpeturene mine, aggregert fra Strava. Jo sterkere farge, jo flere turer har gått samme vei.",
+    "",
 };
 
 export default async function RunningPage() {
+  // Er bryteren av, skal ruten ikke finnes. `notFound` framfor en redirect eller
+  // en «kommer snart»-side: en avslått funksjon skal ikke kunne oppdages ved å
+  // gjette på adressen, og den skal ikke ligge i indeksen.
+  if (!isRunningHeatmapEnabled) notFound();
+
   const queryClient = createQueryClient(false);
 
   // Aggregatet er den tyngste responsen på siden. Hentes den på serveren, står

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,7 +4,7 @@ const BASE_URL = "https://vuhnger.dev";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
-  const routes = ["", "/projects", "/cv", "/master", "/mst"];
+  const routes = ["", "/projects", "/cv", "/master", "/mst", "/running"];
 
   return routes.map((route) => ({
     url: `${BASE_URL}${route}`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,14 @@
 import type { MetadataRoute } from "next";
+import { isRunningHeatmapEnabled } from "@/lib/features";
 
 const BASE_URL = "https://vuhnger.dev";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
-  const routes = ["", "/projects", "/cv", "/master", "/mst", "/running"];
+  // `/running` svarer 404 når bryteren er av, så den skal ikke ligge her og
+  // invitere søkemotorer til en død adresse.
+  const routes = ["", "/projects", "/cv", "/master", "/mst"];
+  if (isRunningHeatmapEnabled) routes.push("/running");
 
   return routes.map((route) => ({
     url: `${BASE_URL}${route}`,

--- a/components/home/BentoGrid.tsx
+++ b/components/home/BentoGrid.tsx
@@ -8,6 +8,7 @@ import { Suspense } from "react";
 import MasterCountdown from "./MasterCountdown";
 import { StatsCardsLoading } from "./StatsCards";
 import PrefetchedStatsCards from "./PrefetchedStatsCards";
+import PrefetchedHeatmapTeaser from "@/components/running/PrefetchedHeatmapTeaser";
 
 const BentoGrid = () => {
   const clickableOutline = '2px solid var(--ds-color-accent-base-default)';
@@ -216,6 +217,11 @@ const BentoGrid = () => {
         <Suspense fallback={<StatsCardsLoading />}>
           <PrefetchedStatsCards />
         </Suspense>
+        <div className="md:col-span-4">
+          <Suspense fallback={null}>
+            <PrefetchedHeatmapTeaser />
+          </Suspense>
+        </div>
       </div>
     </div>
   );

--- a/components/home/BentoGrid.tsx
+++ b/components/home/BentoGrid.tsx
@@ -9,6 +9,7 @@ import MasterCountdown from "./MasterCountdown";
 import { StatsCardsLoading } from "./StatsCards";
 import PrefetchedStatsCards from "./PrefetchedStatsCards";
 import PrefetchedHeatmapTeaser from "@/components/running/PrefetchedHeatmapTeaser";
+import { isRunningHeatmapEnabled } from "@/lib/features";
 
 const BentoGrid = () => {
   const clickableOutline = '2px solid var(--ds-color-accent-base-default)';
@@ -217,11 +218,13 @@ const BentoGrid = () => {
         <Suspense fallback={<StatsCardsLoading />}>
           <PrefetchedStatsCards />
         </Suspense>
-        <div className="md:col-span-4">
-          <Suspense fallback={null}>
-            <PrefetchedHeatmapTeaser />
-          </Suspense>
-        </div>
+        {isRunningHeatmapEnabled && (
+          <div className="md:col-span-4">
+            <Suspense fallback={null}>
+              <PrefetchedHeatmapTeaser />
+            </Suspense>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/layout/ThemeToggle.tsx
+++ b/components/layout/ThemeToggle.tsx
@@ -1,66 +1,15 @@
 "use client";
 
 import { Moon, Sun } from "lucide-react";
-import { useSyncExternalStore } from "react";
-
-type Scheme = "light" | "dark";
-
-const THEME_STORAGE_KEY = "color-scheme";
-const THEME_CHANGE_EVENT = "color-scheme-change";
-
-const getScheme = (): Scheme =>
-  document.documentElement.dataset.colorScheme === "dark" ? "dark" : "light";
-
-const applyScheme = (scheme: Scheme) => {
-  document.documentElement.dataset.colorScheme = scheme;
-  document.documentElement.style.colorScheme = scheme;
-};
-
-const isDaytime = () => {
-  const hour = new Date().getHours();
-  return hour >= 8 && hour < 20;
-};
-
-const DEFAULT_SCHEME_CHECK_INTERVAL_MS = 60_000;
-
-const subscribe = (onStoreChange: () => void) => {
-  const applyDefaultScheme = () => {
-    let storedScheme: string | null = null;
-    try {
-      storedScheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-    } catch {}
-
-    if (storedScheme === "light" || storedScheme === "dark") return;
-
-    applyScheme(isDaytime() ? "light" : "dark");
-    onStoreChange();
-  };
-
-  const intervalId = window.setInterval(applyDefaultScheme, DEFAULT_SCHEME_CHECK_INTERVAL_MS);
-  window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
-
-  return () => {
-    window.clearInterval(intervalId);
-    window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
-  };
-};
+import { setColorScheme, useColorScheme } from "@/lib/color-scheme";
 
 const ThemeToggle = () => {
-  const scheme = useSyncExternalStore(subscribe, getScheme, () => "light");
-
-  const toggleTheme = () => {
-    const nextScheme = scheme === "dark" ? "light" : "dark";
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, nextScheme);
-    } catch {}
-    applyScheme(nextScheme);
-    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
-  };
+  const scheme = useColorScheme();
 
   return (
     <button
       type="button"
-      onClick={toggleTheme}
+      onClick={() => setColorScheme(scheme === "dark" ? "light" : "dark")}
       aria-label={scheme === "dark" ? "Bytt til lys modus" : "Bytt til mørk modus"}
       style={{
         width: '2rem',

--- a/components/running/HeatmapMap.tsx
+++ b/components/running/HeatmapMap.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { MapLibreMap, NavigationControl } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { getColorScheme, useColorScheme } from "@/lib/color-scheme";
+import { toHeatmapGeoJson } from "@/lib/heatmap";
+import type { RunningHeatmap } from "@/services/api/heatmap";
+import { basemapStyleUrl } from "./basemap";
+import {
+  HEATMAP_LAYER_ID,
+  HEATMAP_SOURCE_ID,
+  heatmapPaint,
+  resolveCssColor,
+} from "./heatmap-layer";
+
+const FALLBACK_ACCENT = [37, 99, 235] as const;
+
+const readAccentColor = () => {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(
+    "--ds-color-accent-base-default",
+  );
+  return resolveCssColor(value) ?? FALLBACK_ACCENT;
+};
+
+type HeatmapMapProps = {
+  heatmap: RunningHeatmap;
+  /** Beskriver kartet for skjermlesere, som ikke får noe ut av lerretet. */
+  label: string;
+};
+
+const HeatmapMap = ({ heatmap, label }: HeatmapMapProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const scheme = useColorScheme();
+
+  // Kartet settes opp én gang. Bakgrunnskartet byttes senere med setStyle,
+  // framfor å rive og bygge instansen på nytt hver gang temaet endres.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const map = new MapLibreMap({
+      container,
+      style: basemapStyleUrl(scheme),
+      // Utsnittet settes i konstruktøren framfor med fitBounds, slik at kartet
+      // åpner ferdig plassert. Da finnes det ingen innzooming å hoppe over for
+      // brukere som har slått av bevegelse.
+      bounds: heatmap.bounds,
+      fitBoundsOptions: { padding: 40, animate: false },
+      attributionControl: { compact: true },
+      // Uten dette spiser kartet rullingen når man scroller forbi det.
+      cooperativeGestures: true,
+    });
+
+    mapRef.current = map;
+    map.addControl(new NavigationControl({ showCompass: false }), "top-right");
+    map.getCanvas().setAttribute("aria-label", label);
+
+    // `style.load` kommer både ved oppstart og etter hvert temabytte, så laget
+    // legges tilbake av seg selv når setStyle har tømt stilen.
+    const addHeatmapLayer = () => {
+      if (!map.getSource(HEATMAP_SOURCE_ID)) {
+        map.addSource(HEATMAP_SOURCE_ID, {
+          type: "geojson",
+          data: toHeatmapGeoJson(heatmap.cells),
+        });
+      }
+
+      if (!map.getLayer(HEATMAP_LAYER_ID)) {
+        map.addLayer({
+          id: HEATMAP_LAYER_ID,
+          type: "heatmap",
+          source: HEATMAP_SOURCE_ID,
+          paint: heatmapPaint(readAccentColor(), getColorScheme()),
+        });
+      }
+    };
+
+    map.on("style.load", addHeatmapLayer);
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+    // Utsnitt og data hører til den første oppbyggingen. Temabytte håndteres i
+    // effekten under, så `scheme` skal bevisst ikke bygge kartet på nytt.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heatmap, label]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    map.setStyle(basemapStyleUrl(scheme));
+  }, [scheme]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[60vh] min-h-[380px] w-full"
+      style={{
+        borderRadius: "0.5rem",
+        overflow: "hidden",
+        border: "2px solid var(--ds-color-neutral-border-strong)",
+      }}
+    />
+  );
+};
+
+export default HeatmapMap;

--- a/components/running/HeatmapMap.tsx
+++ b/components/running/HeatmapMap.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from "react";
 import { MapLibreMap, NavigationControl } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { getColorScheme, useColorScheme } from "@/lib/color-scheme";
-import { toHeatmapGeoJson } from "@/lib/heatmap";
+import { dominantClusterBounds, toHeatmapGeoJson } from "@/lib/heatmap";
 import type { RunningHeatmap } from "@/services/api/heatmap";
 import { basemapStyleUrl } from "./basemap";
 import {
@@ -52,7 +52,12 @@ const HeatmapMap = ({ heatmap, label }: HeatmapMapProps) => {
       // Utsnittet settes i konstruktøren framfor med fitBounds, slik at kartet
       // åpner ferdig plassert. Da finnes det ingen innzooming å hoppe over for
       // brukere som har slått av bevegelse.
-      bounds: heatmap.bounds,
+      //
+      // Åpner på den tetteste klyngen, ikke på hele utstrekningen: aggregatet
+      // inneholder ferieturer, og `heatmap.bounds` spenner derfor over halve
+      // Europa. Alle cellene ligger uansett i kartlaget, så turene lenger unna
+      // finnes fortsatt for den som zoomer ut.
+      bounds: dominantClusterBounds(heatmap.cells) ?? heatmap.bounds,
       fitBoundsOptions: { padding: 40, animate: false },
       attributionControl: { compact: true },
       // Uten dette spiser kartet rullingen når man scroller forbi det.

--- a/components/running/HeatmapMap.tsx
+++ b/components/running/HeatmapMap.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+// Låst til 5.x, ikke av latskap: 6.x utleder adressen til sin egen web worker
+// fra `import.meta.url` og gir tom streng med mindre den adressen er http(s).
+// Etter Next-bundlingen er den ikke det, så workeren starter aldri og kartet
+// blir stående tomt. Eneste vei rundt er å legge workeren fra `dist` i
+// `public/` og peke på den med `setWorkerUrl`, altså en kopiert fil som må
+// synkes manuelt ved hver oppgradering. 5.x finner workeren selv.
 import { MapLibreMap, NavigationControl } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { getColorScheme, useColorScheme } from "@/lib/color-scheme";

--- a/components/running/HeatmapTeaser.tsx
+++ b/components/running/HeatmapTeaser.tsx
@@ -1,7 +1,7 @@
 import { Link as NextLink } from "next-view-transitions";
 import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
 import { Activity } from "lucide-react";
-import { rasterizeCells } from "@/lib/heatmap";
+import { cellsWithinBounds, dominantClusterBounds, rasterizeCells } from "@/lib/heatmap";
 import type { RunningHeatmap } from "@/services/api/heatmap";
 
 // Omtrent kvadratisk, fordi utstrekningen på turene er det. Et bredere utsnitt
@@ -29,9 +29,14 @@ const cardStyle = {
 };
 
 const HeatmapTeaser = ({ heatmap }: { heatmap: RunningHeatmap }) => {
+  // Utstrekningen fra backend dekker ferieturer i andre land, så den ville
+  // krympet Oslo til noen få piksler. Teaseren viser bare den tetteste klyngen,
+  // og cellene utenfor filtreres vekk — ellers ville de blitt klemt inn til
+  // kanten av flaten og lagt seg der som varme som ikke finnes.
+  const bounds = dominantClusterBounds(heatmap.cells) ?? heatmap.bounds;
   const points = rasterizeCells(
-    heatmap.cells,
-    heatmap.bounds,
+    cellsWithinBounds(heatmap.cells, bounds),
+    bounds,
     TEASER_WIDTH,
     TEASER_HEIGHT,
     TEASER_PIXEL_SIZE,

--- a/components/running/HeatmapTeaser.tsx
+++ b/components/running/HeatmapTeaser.tsx
@@ -1,0 +1,109 @@
+import { Link as NextLink } from "next-view-transitions";
+import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
+import { Activity } from "lucide-react";
+import { rasterizeCells } from "@/lib/heatmap";
+import type { RunningHeatmap } from "@/services/api/heatmap";
+
+// Omtrent kvadratisk, fordi utstrekningen på turene er det. Et bredere utsnitt
+// ville bare lagt til tom luft på sidene.
+const TEASER_WIDTH = 300;
+const TEASER_HEIGHT = 260;
+
+/**
+ * Rutestørrelsen i piksler. En 15-meters celle er uansett mindre enn en piksel
+ * i denne størrelsen, så å tegne hver enkelt ville lagt tusenvis av elementer i
+ * HTML-en uten å endre hva man ser.
+ */
+const TEASER_PIXEL_SIZE = 3;
+
+const formatKm = (meters: number) =>
+  new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(meters / 1000);
+
+const cardStyle = {
+  padding: "0.75rem",
+  height: "100%",
+  backgroundColor: "color-mix(in srgb, var(--ds-color-neutral-background-default) 85%, transparent)",
+  border: "2px solid var(--ds-color-accent-base-default)",
+  boxShadow: "var(--accent-shadow)",
+  cursor: "pointer",
+};
+
+const HeatmapTeaser = ({ heatmap }: { heatmap: RunningHeatmap }) => {
+  const points = rasterizeCells(
+    heatmap.cells,
+    heatmap.bounds,
+    TEASER_WIDTH,
+    TEASER_HEIGHT,
+    TEASER_PIXEL_SIZE,
+  );
+
+  return (
+    <NextLink
+      href="/running"
+      aria-label="Løping"
+      className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-color-accent-base-default)] focus-visible:ring-offset-2"
+    >
+      <Card
+        className="relative overflow-hidden transition hover:-translate-y-0.5 hover:shadow-sm motion-reduce:transform-none"
+        style={cardStyle}
+      >
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+          <div className="order-2 sm:order-1">
+            <div className="flex items-center gap-2">
+              <Activity
+                aria-hidden="true"
+                size={19}
+                strokeWidth={2.25}
+                absoluteStrokeWidth
+                style={{ color: "var(--ds-color-accent-base-default)" }}
+              />
+              <Heading
+                data-size="xs"
+                style={{ margin: 0, color: "var(--ds-color-accent-base-default)" }}
+              >
+                Løping
+              </Heading>
+            </div>
+            <Paragraph
+              data-size="xs"
+              style={{ margin: "0.25rem 0 0", color: "var(--ds-color-neutral-text-default)" }}
+            >
+              {heatmap.activityCount} turer · {formatKm(heatmap.totalDistanceM)} km
+            </Paragraph>
+            <Paragraph
+              data-size="xs"
+              style={{ margin: 0, color: "var(--ds-color-neutral-text-subtle)", opacity: 0.78 }}
+            >
+              Se hele varmekartet
+            </Paragraph>
+          </div>
+
+          {/*
+            Dekorativt: alt kartet forteller står allerede i teksten ved siden av,
+            så en skjermleser skal hoppe over det framfor å få en beskrivelse til.
+          */}
+          <svg
+            className="order-1 h-28 w-auto sm:order-2 sm:h-32"
+            viewBox={`0 0 ${TEASER_WIDTH} ${TEASER_HEIGHT}`}
+            aria-hidden="true"
+            focusable="false"
+          >
+            {points.map((point) => (
+              <circle
+                key={`${point.x}:${point.y}`}
+                cx={point.x}
+                cy={point.y}
+                r={TEASER_PIXEL_SIZE / 2}
+                fill="var(--ds-color-accent-base-default)"
+                // Gjentatte ruter lyser sterkere, akkurat som i det store kartet.
+                fillOpacity={(0.25 + 0.75 * point.weight).toFixed(2)}
+              />
+            ))}
+          </svg>
+        </div>
+      </Card>
+    </NextLink>
+  );
+};
+
+export default HeatmapTeaser;

--- a/components/running/HeatmapTeaser.tsx
+++ b/components/running/HeatmapTeaser.tsx
@@ -1,5 +1,5 @@
 import { Link as NextLink } from "next-view-transitions";
-import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
+import { Card, Heading } from "@digdir/designsystemet-react";
 import { Activity } from "lucide-react";
 import { cellsWithinBounds, dominantClusterBounds, rasterizeCells } from "@/lib/heatmap";
 import type { RunningHeatmap } from "@/services/api/heatmap";
@@ -15,9 +15,6 @@ const TEASER_HEIGHT = 260;
  * HTML-en uten å endre hva man ser.
  */
 const TEASER_PIXEL_SIZE = 3;
-
-const formatKm = (meters: number) =>
-  new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(meters / 1000);
 
 const cardStyle = {
   padding: "0.75rem",
@@ -45,7 +42,9 @@ const HeatmapTeaser = ({ heatmap }: { heatmap: RunningHeatmap }) => {
   return (
     <NextLink
       href="/running"
-      aria-label="Løping"
+      // Ingen aria-label: overskriften i kortet er allerede lenkens navn, og en
+      // egen merkelapp med annen ordlyd ville gjort at det man hører ikke er det
+      // man ser.
       className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-color-accent-base-default)] focus-visible:ring-offset-2"
     >
       <Card
@@ -66,26 +65,17 @@ const HeatmapTeaser = ({ heatmap }: { heatmap: RunningHeatmap }) => {
                 data-size="xs"
                 style={{ margin: 0, color: "var(--ds-color-accent-base-default)" }}
               >
-                Løping
+                Heatmap art
               </Heading>
             </div>
-            <Paragraph
-              data-size="xs"
-              style={{ margin: "0.25rem 0 0", color: "var(--ds-color-neutral-text-default)" }}
-            >
-              {heatmap.activityCount} turer · {formatKm(heatmap.totalDistanceM)} km
-            </Paragraph>
-            <Paragraph
-              data-size="xs"
-              style={{ margin: 0, color: "var(--ds-color-neutral-text-subtle)", opacity: 0.78 }}
-            >
-              Se hele varmekartet
-            </Paragraph>
+            
+            
           </div>
 
           {/*
-            Dekorativt: alt kartet forteller står allerede i teksten ved siden av,
-            så en skjermleser skal hoppe over det framfor å få en beskrivelse til.
+            Dekorativt. Punktskyen er en stemningsskisse i kortformat, ikke et kart
+            man kan lese noe presist ut av, så en skjermleser skal hoppe over den
+            framfor å få den beskrevet.
           */}
           <svg
             className="order-1 h-28 w-auto sm:order-2 sm:h-32"

--- a/components/running/PrefetchedHeatmapTeaser.tsx
+++ b/components/running/PrefetchedHeatmapTeaser.tsx
@@ -1,0 +1,29 @@
+import { createQueryClient } from "@/lib/query-client";
+import HeatmapTeaser from "./HeatmapTeaser";
+import { runningHeatmapQueryOptions } from "./queries";
+
+/**
+ * Teaseren er ren serverrendering: den er et bilde uten interaksjon, så
+ * ingenting av dette trenger å følge med til nettleseren.
+ *
+ * Feiler kallet, faller kortet bort. Forsiden har ingen nytte av et varmekart
+ * uten kart, og et halvtomt kort ville sett ut som en feil framfor et valg.
+ */
+const loadHeatmap = async () => {
+  const queryClient = createQueryClient(false);
+
+  try {
+    return await queryClient.fetchQuery(runningHeatmapQueryOptions());
+  } catch {
+    return null;
+  }
+};
+
+const PrefetchedHeatmapTeaser = async () => {
+  const heatmap = await loadHeatmap();
+  if (!heatmap || heatmap.cells.length === 0) return null;
+
+  return <HeatmapTeaser heatmap={heatmap} />;
+};
+
+export default PrefetchedHeatmapTeaser;

--- a/components/running/RunningHeatmap.tsx
+++ b/components/running/RunningHeatmap.tsx
@@ -45,10 +45,14 @@ const RunningHeatmap = () => {
     return "Kartet er klart.";
   };
 
+  // Tallene beskriver all løpingen, ikke det kartet viser: `activityCount` teller
+  // også tredemølleturer, som ikke har GPS og dermed ingen geometri å tegne. De
+  // står derfor som en egen opplysning framfor «varmekart over N turer», som
+  // ville vært en påstand om kartet som ikke holder.
   const summary = heatmap
-    ? `Varmekart over ${heatmap.activityCount} løpeturer, til sammen ${formatKm(
+    ? `Varmekart over løpeturene mine. ${heatmap.activityCount} turer og ${formatKm(
         heatmap.totalDistanceM,
-      )} kilometer.`
+      )} kilometer til sammen.`
     : null;
 
   return (
@@ -80,8 +84,9 @@ const RunningHeatmap = () => {
               data-size="sm"
               style={{ marginTop: "0.75rem", marginBottom: 0, color: "var(--ds-color-neutral-text-subtle)" }}
             >
-              {summary} Jo sterkere farge, jo flere turer har gått samme vei. Området rundt
-              hjemmet mitt er filtrert bort.
+              {summary} Kartet åpner over Oslo, der jeg løper mest — zoom ut for turer
+              lenger unna. Jo sterkere farge, jo flere turer har gått samme vei. Turer
+              uten GPS vises ikke, og området rundt hjemmet mitt er filtrert bort.
             </Paragraph>
           </figcaption>
         </figure>

--- a/components/running/RunningHeatmap.tsx
+++ b/components/running/RunningHeatmap.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Paragraph } from "@digdir/designsystemet-react";
+import { useQuery } from "@tanstack/react-query";
+import { runningHeatmapQueryOptions } from "./queries";
+
+/**
+ * Kartbiblioteket er tungt og rører DOM-et med én gang, så det holdes utenfor
+ * serverrenderingen og lastes først når kartet faktisk skal vises.
+ */
+const HeatmapMap = dynamic(() => import("./HeatmapMap"), {
+  ssr: false,
+  loading: () => <MapPlaceholder>Laster kart...</MapPlaceholder>,
+});
+
+const formatKm = (meters: number) =>
+  new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(meters / 1000);
+
+const MapPlaceholder = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className="flex h-[60vh] min-h-[380px] w-full items-center justify-center"
+    style={{
+      borderRadius: "0.5rem",
+      border: "2px solid var(--ds-color-neutral-border-strong)",
+      backgroundColor: "var(--ds-color-neutral-background-tinted)",
+    }}
+  >
+    <Paragraph data-size="sm" style={{ margin: 0 }}>
+      {children}
+    </Paragraph>
+  </div>
+);
+
+const RunningHeatmap = () => {
+  const { data, isPending, isError } = useQuery(runningHeatmapQueryOptions());
+
+  if (isPending) {
+    return (
+      <div aria-busy="true">
+        <MapPlaceholder>Henter løpedata...</MapPlaceholder>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <MapPlaceholder>
+        Fikk ikke tak i løpedataen akkurat nå. Prøv igjen senere.
+      </MapPlaceholder>
+    );
+  }
+
+  if (data.cells.length === 0) {
+    return <MapPlaceholder>Ingen turer å vise ennå.</MapPlaceholder>;
+  }
+
+  const summary = `Varmekart over ${data.activityCount} løpeturer, til sammen ${formatKm(
+    data.totalDistanceM,
+  )} kilometer.`;
+
+  return (
+    <figure style={{ margin: 0 }}>
+      {/*
+        Lerretet har ikke noe innhold en skjermleser kan lese, og oppsummeringen
+        under er uansett den informasjonen kartet formidler. Den dobles derfor
+        som tilgjengelig navn framfor at kartet blir et tomt element.
+      */}
+      <HeatmapMap heatmap={data} label={summary} />
+      <figcaption>
+        <Paragraph
+          data-size="sm"
+          style={{ marginTop: "0.75rem", marginBottom: 0, color: "var(--ds-color-neutral-text-subtle)" }}
+        >
+          {summary} Jo sterkere farge, jo flere turer har gått samme vei. Området rundt
+          hjemmet mitt er filtrert bort.
+        </Paragraph>
+      </figcaption>
+    </figure>
+  );
+};
+
+export default RunningHeatmap;

--- a/components/running/RunningHeatmap.tsx
+++ b/components/running/RunningHeatmap.tsx
@@ -34,49 +34,59 @@ const MapPlaceholder = ({ children }: { children: React.ReactNode }) => (
 
 const RunningHeatmap = () => {
   const { data, isPending, isError } = useQuery(runningHeatmapQueryOptions());
+  const heatmap = data && data.cells.length > 0 ? data : null;
 
-  if (isPending) {
-    return (
-      <div aria-busy="true">
-        <MapPlaceholder>Henter løpedata...</MapPlaceholder>
-      </div>
-    );
-  }
+  const statusMessage = () => {
+    if (isPending) return "Henter løpedata...";
+    if (isError) return "Fikk ikke tak i løpedataen akkurat nå. Prøv igjen senere.";
+    if (!heatmap) return "Ingen turer å vise ennå.";
+    // Kartet står for seg selv visuelt, så her trengs bare bekreftelsen på at
+    // ventingen er over. Tallene ligger i teksten under kartet.
+    return "Kartet er klart.";
+  };
 
-  if (isError) {
-    return (
-      <MapPlaceholder>
-        Fikk ikke tak i løpedataen akkurat nå. Prøv igjen senere.
-      </MapPlaceholder>
-    );
-  }
-
-  if (data.cells.length === 0) {
-    return <MapPlaceholder>Ingen turer å vise ennå.</MapPlaceholder>;
-  }
-
-  const summary = `Varmekart over ${data.activityCount} løpeturer, til sammen ${formatKm(
-    data.totalDistanceM,
-  )} kilometer.`;
+  const summary = heatmap
+    ? `Varmekart over ${heatmap.activityCount} løpeturer, til sammen ${formatKm(
+        heatmap.totalDistanceM,
+      )} kilometer.`
+    : null;
 
   return (
-    <figure style={{ margin: 0 }}>
+    <>
       {/*
-        Lerretet har ikke noe innhold en skjermleser kan lese, og oppsummeringen
-        under er uansett den informasjonen kartet formidler. Den dobles derfor
-        som tilgjengelig navn framfor at kartet blir et tomt element.
+        Live-regionen står montert i alle tilstander. Byttet fra venting til feil
+        eller ferdig kart skjer etter at siden er lest opp, og en region som først
+        dukker opp sammen med meldingen blir ikke annonsert i det hele tatt.
       */}
-      <HeatmapMap heatmap={data} label={summary} />
-      <figcaption>
-        <Paragraph
-          data-size="sm"
-          style={{ marginTop: "0.75rem", marginBottom: 0, color: "var(--ds-color-neutral-text-subtle)" }}
-        >
-          {summary} Jo sterkere farge, jo flere turer har gått samme vei. Området rundt
-          hjemmet mitt er filtrert bort.
-        </Paragraph>
-      </figcaption>
-    </figure>
+      <div role="status" aria-busy={isPending}>
+        {heatmap ? (
+          <span className="sr-only">{statusMessage()}</span>
+        ) : (
+          <MapPlaceholder>{statusMessage()}</MapPlaceholder>
+        )}
+      </div>
+
+      {heatmap && summary && (
+        <figure style={{ margin: 0 }}>
+          {/*
+            Lerretet har ikke noe innhold en skjermleser kan lese, og
+            oppsummeringen under er uansett den informasjonen kartet formidler.
+            Den dobles derfor som tilgjengelig navn framfor at kartet blir et
+            tomt element.
+          */}
+          <HeatmapMap heatmap={heatmap} label={summary} />
+          <figcaption>
+            <Paragraph
+              data-size="sm"
+              style={{ marginTop: "0.75rem", marginBottom: 0, color: "var(--ds-color-neutral-text-subtle)" }}
+            >
+              {summary} Jo sterkere farge, jo flere turer har gått samme vei. Området rundt
+              hjemmet mitt er filtrert bort.
+            </Paragraph>
+          </figcaption>
+        </figure>
+      )}
+    </>
   );
 };
 

--- a/components/running/RunningHeatmap.tsx
+++ b/components/running/RunningHeatmap.tsx
@@ -14,8 +14,12 @@ const HeatmapMap = dynamic(() => import("./HeatmapMap"), {
   loading: () => <MapPlaceholder>Laster kart...</MapPlaceholder>,
 });
 
-const formatKm = (meters: number) =>
-  new Intl.NumberFormat("no-NO", { maximumFractionDigits: 0 }).format(meters / 1000);
+/**
+ * Lerretet har ikke noe innhold en skjermleser kan lese, så uten et navn blir
+ * kartet et tomt element. Holdes kort og usynlig — det er en merkelapp, ikke en
+ * bildetekst.
+ */
+const MAP_LABEL = "Varmekart over løpeturene mine";
 
 const MapPlaceholder = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -40,20 +44,10 @@ const RunningHeatmap = () => {
     if (isPending) return "Henter løpedata...";
     if (isError) return "Fikk ikke tak i løpedataen akkurat nå. Prøv igjen senere.";
     if (!heatmap) return "Ingen turer å vise ennå.";
-    // Kartet står for seg selv visuelt, så her trengs bare bekreftelsen på at
-    // ventingen er over. Tallene ligger i teksten under kartet.
+    // Kartet står for seg selv visuelt. Her trengs bare bekreftelsen på at
+    // ventingen er over, for den som ikke ser at lerretet ble fylt.
     return "Kartet er klart.";
   };
-
-  // Tallene beskriver all løpingen, ikke det kartet viser: `activityCount` teller
-  // også tredemølleturer, som ikke har GPS og dermed ingen geometri å tegne. De
-  // står derfor som en egen opplysning framfor «varmekart over N turer», som
-  // ville vært en påstand om kartet som ikke holder.
-  const summary = heatmap
-    ? `Varmekart over løpeturene mine. ${heatmap.activityCount} turer og ${formatKm(
-        heatmap.totalDistanceM,
-      )} kilometer til sammen.`
-    : null;
 
   return (
     <>
@@ -70,27 +64,7 @@ const RunningHeatmap = () => {
         )}
       </div>
 
-      {heatmap && summary && (
-        <figure style={{ margin: 0 }}>
-          {/*
-            Lerretet har ikke noe innhold en skjermleser kan lese, og
-            oppsummeringen under er uansett den informasjonen kartet formidler.
-            Den dobles derfor som tilgjengelig navn framfor at kartet blir et
-            tomt element.
-          */}
-          <HeatmapMap heatmap={heatmap} label={summary} />
-          <figcaption>
-            <Paragraph
-              data-size="sm"
-              style={{ marginTop: "0.75rem", marginBottom: 0, color: "var(--ds-color-neutral-text-subtle)" }}
-            >
-              {summary} Kartet åpner over Oslo, der jeg løper mest — zoom ut for turer
-              lenger unna. Jo sterkere farge, jo flere turer har gått samme vei. Turer
-              uten GPS vises ikke, og området rundt hjemmet mitt er filtrert bort.
-            </Paragraph>
-          </figcaption>
-        </figure>
-      )}
+      {heatmap && <HeatmapMap heatmap={heatmap} label={MAP_LABEL} />}
     </>
   );
 };

--- a/components/running/RunningHeatmap.tsx
+++ b/components/running/RunningHeatmap.tsx
@@ -44,9 +44,11 @@ const RunningHeatmap = () => {
     if (isPending) return "Henter løpedata...";
     if (isError) return "Fikk ikke tak i løpedataen akkurat nå. Prøv igjen senere.";
     if (!heatmap) return "Ingen turer å vise ennå.";
-    // Kartet står for seg selv visuelt. Her trengs bare bekreftelsen på at
-    // ventingen er over, for den som ikke ser at lerretet ble fylt.
-    return "Kartet er klart.";
+    // Sier bevisst «hentet», ikke «klart»: kartbiblioteket lastes som en egen
+    // chunk, så spørringen kan være ferdig mens lerretet ennå viser
+    // reservevisningen. Å melde kartet klart før det er tegnet ville sendt en
+    // skjermleserbruker til et element som ikke finnes enda.
+    return "Løpedataen er hentet.";
   };
 
   return (

--- a/components/running/basemap.ts
+++ b/components/running/basemap.ts
@@ -1,0 +1,18 @@
+import type { ColorScheme } from "@/lib/color-scheme";
+
+/**
+ * CARTO sine grunnkart er gratis og krever ingen nøkkel, og de finnes i en lys
+ * og en mørk variant som følger temaet på siden. De er bevisst nedtonede, slik
+ * at varmekartet er det man ser først.
+ *
+ * URL-ene kan overstyres med miljøvariabler for å bytte leverandør eller peke
+ * på en selvhostet stil uten kodeendring.
+ */
+const DEFAULT_LIGHT_STYLE = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+const DEFAULT_DARK_STYLE = "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json";
+
+const lightStyle = process.env.NEXT_PUBLIC_BASEMAP_STYLE_LIGHT || DEFAULT_LIGHT_STYLE;
+const darkStyle = process.env.NEXT_PUBLIC_BASEMAP_STYLE_DARK || DEFAULT_DARK_STYLE;
+
+export const basemapStyleUrl = (scheme: ColorScheme): string =>
+  scheme === "dark" ? darkStyle : lightStyle;

--- a/components/running/heatmap-layer.ts
+++ b/components/running/heatmap-layer.ts
@@ -1,0 +1,137 @@
+import type { AddLayerObject } from "maplibre-gl";
+import type { ColorScheme } from "@/lib/color-scheme";
+
+export const HEATMAP_SOURCE_ID = "running-heatmap-cells";
+export const HEATMAP_LAYER_ID = "running-heatmap";
+
+/**
+ * Kartbiblioteket eksporterer ikke lagspesifikasjonene enkeltvis, så typen
+ * plukkes ut av unionen. Da får uttrykkene under ekte typesjekk framfor å bli
+ * castet inn i `addLayer`.
+ */
+type HeatmapPaint = NonNullable<Extract<AddLayerObject, { type: "heatmap" }>["paint"]>;
+
+type Rgb = readonly [number, number, number];
+
+/**
+ * Designsystemet eksponerer fargene som CSS-variabler, og kartbiblioteket kan
+ * ikke lese dem — det trenger konkrete fargeverdier i stilobjektet.
+ *
+ * Verdien males derfor på et 1x1-lerret og leses tilbake som piksel. Da er det
+ * nettleserens egen fargeparser som gjør jobben, og oppslaget fortsetter å virke
+ * uansett hvilken syntaks temaet bruker. Variablene er hex i dag, men
+ * Designsystemet leverer `oklch` fra egen temabygger, og det ville ellers
+ * knekt stille ved neste temabytte.
+ */
+export function resolveCssColor(value: string): Rgb | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Ugyldige verdier lar `fillStyle` stå urørt, så lerretet ville rapportert
+  // forrige farge framfor å feile. Valideringen må skje før vi maler.
+  if (typeof CSS === "undefined" || !CSS.supports("color", trimmed)) return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (!context) return null;
+
+  context.fillStyle = trimmed;
+  context.fillRect(0, 0, 1, 1);
+
+  const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
+  return [red, green, blue];
+}
+
+const rgba = (color: Rgb, alpha: number) => `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${alpha})`;
+
+const mix = (color: Rgb, target: Rgb, amount: number): Rgb => [
+  Math.round(color[0] + (target[0] - color[0]) * amount),
+  Math.round(color[1] + (target[1] - color[1]) * amount),
+  Math.round(color[2] + (target[2] - color[2]) * amount),
+];
+
+const WHITE: Rgb = [255, 255, 255];
+const INK: Rgb = [12, 20, 38];
+
+/**
+ * Toppen av skalaen må bevege seg bort fra bakgrunnen, ikke mot den. På det
+ * mørke bakgrunnskartet betyr det at de mest brukte rutene lyser opp mot hvitt,
+ * på det lyse at de går mot dypt blåsvart. Samme aksentfarge i bunnen begge
+ * veier, så kartet fortsatt ser ut som resten av siden.
+ */
+const peakTarget = (scheme: ColorScheme): Rgb => (scheme === "dark" ? WHITE : INK);
+
+export function heatmapColorRamp(accent: Rgb, scheme: ColorScheme): HeatmapPaint["heatmap-color"] {
+  const peak = peakTarget(scheme);
+
+  return [
+    "interpolate",
+    ["linear"],
+    ["heatmap-density"],
+    // Nullpunktet må være helt gjennomsiktig, ellers legger laget en heldekkende
+    // flate over hele kartet i stedet for bare der det er løpt.
+    0,
+    rgba(accent, 0),
+    0.15,
+    rgba(accent, 0.35),
+    0.4,
+    rgba(accent, 0.75),
+    0.65,
+    rgba(accent, 1),
+    0.85,
+    rgba(mix(accent, peak, 0.45), 1),
+    1,
+    rgba(mix(accent, peak, 0.8), 1),
+  ];
+}
+
+/**
+ * Radiusen er oppgitt i skjermpiksler, mens cellene har fast størrelse i meter.
+ * Uten zoomskalering blir kartet enten en grøt på lang avstand eller løsrevne
+ * prikker på nært hold. Stoppene følger meter-per-piksel omtrent, men flater ut
+ * i begge ender: helt tro skalering ville gitt under én piksel på bynivå.
+ */
+const heatmapRadius: HeatmapPaint["heatmap-radius"] = [
+  "interpolate",
+  ["exponential", 1.6],
+  ["zoom"],
+  9,
+  2,
+  12,
+  5,
+  15,
+  13,
+  18,
+  32,
+];
+
+/**
+ * Tettheten legges sammen per piksel, så jo lenger ut man zoomer, jo flere
+ * celler bidrar til samme punkt. Intensiteten dempes derfor på lavt zoomnivå
+ * for at oversiktsbildet ikke skal gå i metning.
+ */
+const heatmapIntensity: HeatmapPaint["heatmap-intensity"] = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  9,
+  0.6,
+  13,
+  1,
+  18,
+  2.2,
+];
+
+export function heatmapPaint(accent: Rgb, scheme: ColorScheme): HeatmapPaint {
+  return {
+    // Vekten er allerede normalisert til 0-1 mot den travleste cellen.
+    "heatmap-weight": ["get", "weight"],
+    "heatmap-intensity": heatmapIntensity,
+    "heatmap-color": heatmapColorRamp(accent, scheme),
+    "heatmap-radius": heatmapRadius,
+    "heatmap-opacity": scheme === "dark" ? 0.9 : 0.8,
+  };
+}

--- a/lib/color-scheme.ts
+++ b/lib/color-scheme.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export type ColorScheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "color-scheme";
+export const THEME_CHANGE_EVENT = "color-scheme-change";
+
+export const getColorScheme = (): ColorScheme =>
+  document.documentElement.dataset.colorScheme === "dark" ? "dark" : "light";
+
+export const applyColorScheme = (scheme: ColorScheme) => {
+  document.documentElement.dataset.colorScheme = scheme;
+  document.documentElement.style.colorScheme = scheme;
+};
+
+export const setColorScheme = (scheme: ColorScheme) => {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, scheme);
+  } catch {}
+  applyColorScheme(scheme);
+  window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+};
+
+const isDaytime = () => {
+  const hour = new Date().getHours();
+  return hour >= 8 && hour < 20;
+};
+
+const DEFAULT_SCHEME_CHECK_INTERVAL_MS = 60_000;
+
+const subscribe = (onStoreChange: () => void) => {
+  const applyDefaultScheme = () => {
+    let storedScheme: string | null = null;
+    try {
+      storedScheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+    } catch {}
+
+    if (storedScheme === "light" || storedScheme === "dark") return;
+
+    applyColorScheme(isDaytime() ? "light" : "dark");
+    onStoreChange();
+  };
+
+  const intervalId = window.setInterval(applyDefaultScheme, DEFAULT_SCHEME_CHECK_INTERVAL_MS);
+  window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+
+  return () => {
+    window.clearInterval(intervalId);
+    window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  };
+};
+
+/**
+ * Fargetemaet ligger på `documentElement` og byttes både av brukeren og av en
+ * klokkestyrt standard. Kartet må vite om det for å bytte bakgrunnskart, så
+ * abonnementet bor her framfor inne i temaknappen.
+ */
+export const useColorScheme = (): ColorScheme =>
+  useSyncExternalStore(subscribe, getColorScheme, () => "light");

--- a/lib/features.test.ts
+++ b/lib/features.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { isFeatureEnabled } from "./features";
+
+describe("isFeatureEnabled", () => {
+  it("er av når variabelen ikke er satt", () => {
+    expect(isFeatureEnabled(undefined)).toBe(false);
+  });
+
+  it("er av for tom streng", () => {
+    // Compose og en del CI-systemer sender tom streng for en uteglemt variabel.
+    expect(isFeatureEnabled("")).toBe(false);
+  });
+
+  it("slås på av 'true', uansett store bokstaver og mellomrom", () => {
+    for (const value of ["true", "TRUE", "True", " true "]) {
+      expect(isFeatureEnabled(value)).toBe(true);
+    }
+  });
+
+  it("lar seg ikke slå på av noe annet enn 'true'", () => {
+    // Bevisst strengt: en bryter som skrus på av «1» eller «yes» inviterer til
+    // at noen tror «0» eller «no» skrur den av, og da er den på.
+    for (const value of ["1", "yes", "on", "enabled", "false", "0", "off"]) {
+      expect(isFeatureEnabled(value)).toBe(false);
+    }
+  });
+});

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -1,0 +1,24 @@
+/**
+ * Funksjonsbrytere.
+ *
+ * Leses på serveren, ikke i nettleseren: alt som gates her ligger i Server
+ * Components, så verdien trenger ikke ut til klienten. Uten `NEXT_PUBLIC_`
+ * havner den heller ikke i klientbunten.
+ *
+ * Alle brytere er av som standard. En bryter som må slås eksplisitt på kan ikke
+ * lekke ut i produksjon fordi noen glemte å sette den; motsatt vei kan den det.
+ */
+export function isFeatureEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+/**
+ * Varmekartet over løpeturer: både `/running` og teaseren på forsiden.
+ *
+ * Verdien leses ved modulinnlasting, som for statisk prerenderte sider betyr
+ * ved bygg. Å endre bryteren krever altså ny deploy — den er en utrullingsbryter,
+ * ikke en kill switch man kan vri på i drift.
+ */
+export const isRunningHeatmapEnabled = isFeatureEnabled(
+  process.env.RUNNING_HEATMAP_ENABLED,
+);

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  cellsWithinBounds,
+  dominantClusterBounds,
   maxCellCount,
   normalizeWeight,
   projectCells,
@@ -125,6 +127,53 @@ describe("projectCells", () => {
     const projected = projectCells([cell(0, 10, 1), cell(10, 0, 40)], bounds, 100, 100);
     expect(projected[1].weight).toBe(1);
     expect(projected[0].weight).toBeLessThan(1);
+  });
+});
+
+describe("dominantClusterBounds", () => {
+  // Oslo-aktig klynge mot en ferietur i Sør-Frankrike, som er formen på ekte data.
+  const oslo = [cell(10.7, 59.92, 30), cell(10.71, 59.93, 25), cell(10.72, 59.94, 20)];
+  const nice = [cell(7.0, 43.55, 2), cell(7.01, 43.56, 1)];
+
+  it("velger klyngen med flest treff, ikke den med flest celler", () => {
+    // Ferieklyngen har flere celler, men langt færre treff.
+    const many = Array.from({ length: 20 }, (_, i) => cell(7 + i * 0.001, 43.55, 1));
+    const bounds = dominantClusterBounds([...oslo, ...many]);
+
+    expect(bounds).toEqual([10.7, 59.92, 10.72, 59.94]);
+  });
+
+  it("holder fjerne turer utenfor utstrekningen", () => {
+    const bounds = dominantClusterBounds([...oslo, ...nice]);
+
+    expect(bounds).toEqual([10.7, 59.92, 10.72, 59.94]);
+  });
+
+  it("samler naboruter i samme klynge, også på skrå", () => {
+    // Under én rutebredde fra hverandre, men på hver sin side av et rutehjørne.
+    const bounds = dominantClusterBounds([cell(10.24, 59.99, 5), cell(10.26, 60.01, 5)]);
+
+    expect(bounds).toEqual([10.24, 59.99, 10.26, 60.01]);
+  });
+
+  it("faller tilbake til null for et tomt datasett", () => {
+    expect(dominantClusterBounds([])).toBeNull();
+  });
+
+  it("takler at alt ligger i én celle", () => {
+    expect(dominantClusterBounds([cell(10.7, 59.92, 1)])).toEqual([10.7, 59.92, 10.7, 59.92]);
+  });
+});
+
+describe("cellsWithinBounds", () => {
+  it("beholder cellene innenfor og på kanten", () => {
+    const cells = [cell(0, 0, 1), cell(5, 5, 1), cell(10, 10, 1), cell(11, 5, 1)];
+
+    expect(cellsWithinBounds(cells, [0, 0, 10, 10])).toEqual([
+      cell(0, 0, 1),
+      cell(5, 5, 1),
+      cell(10, 10, 1),
+    ]);
   });
 });
 

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -167,6 +167,28 @@ describe("rasterizeCells", () => {
     expect(point.y).toBe(10);
   });
 
+  it("keeps the cells at the far edge inside the drawing area", () => {
+    // Utstrekningen kommer fra cellene, så hjørnecellene projiseres til presis
+    // 100. De skal havne i siste rute, ikke i en egen rute utenfor flaten.
+    const corners = [cell(0, 10, 1), cell(10, 0, 1), cell(10, 10, 1)];
+
+    for (const point of rasterizeCells(corners, bounds, 100, 100, 20)) {
+      expect(point.x).toBeGreaterThanOrEqual(0);
+      expect(point.x).toBeLessThanOrEqual(100);
+      expect(point.y).toBeGreaterThanOrEqual(0);
+      expect(point.y).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("pulls a partial final square in from the edge", () => {
+    // 100px deles ikke jevnt på 30, så siste rute dekker bare 90..100. Sentrum
+    // skal ligge på 95, ikke på 105 som en full rute ville gitt.
+    const [point] = rasterizeCells([cell(10, 0, 1)], bounds, 100, 100, 30);
+
+    expect(point.x).toBe(95);
+    expect(point.y).toBe(95);
+  });
+
   it("falls back to per-cell projection when the grid is disabled", () => {
     const cells = [cell(0.01, 9.99, 1), cell(0.02, 9.98, 1)];
 

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -229,6 +229,19 @@ describe("rasterizeCells", () => {
     }
   });
 
+  it("holder også celler vest og nord for utsnittet innenfor flaten", () => {
+    // Et snevrere utsnitt enn dataene, slik teaseren bruker det. Uten klemming i
+    // begge retninger blir ruten negativ og tegnes utenfor viewBoxen.
+    const outside = [cell(-5, 15, 1), cell(-1, 12, 1), cell(15, -5, 1)];
+
+    for (const point of rasterizeCells(outside, bounds, 100, 100, 20)) {
+      expect(point.x).toBeGreaterThanOrEqual(0);
+      expect(point.x).toBeLessThanOrEqual(100);
+      expect(point.y).toBeGreaterThanOrEqual(0);
+      expect(point.y).toBeLessThanOrEqual(100);
+    }
+  });
+
   it("pulls a partial final square in from the edge", () => {
     // 100px deles ikke jevnt på 30, så siste rute dekker bare 90..100. Sentrum
     // skal ligge på 95, ikke på 105 som en full rute ville gitt.

--- a/lib/heatmap.test.ts
+++ b/lib/heatmap.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { maxCellCount, normalizeWeight, projectCells, toHeatmapGeoJson } from "./heatmap";
+import {
+  maxCellCount,
+  normalizeWeight,
+  projectCells,
+  rasterizeCells,
+  toHeatmapGeoJson,
+} from "./heatmap";
 import type { HeatmapBounds, HeatmapCell } from "@/services/api/heatmap";
 
 const cell = (lon: number, lat: number, count: number): HeatmapCell => ({ lon, lat, count });
@@ -119,5 +125,57 @@ describe("projectCells", () => {
     const projected = projectCells([cell(0, 10, 1), cell(10, 0, 40)], bounds, 100, 100);
     expect(projected[1].weight).toBe(1);
     expect(projected[0].weight).toBeLessThan(1);
+  });
+});
+
+describe("rasterizeCells", () => {
+  const bounds: HeatmapBounds = [0, 0, 10, 10];
+
+  it("collapses cells that land in the same grid square", () => {
+    // Tre celler så tett at de havner innenfor samme 20px-rute.
+    const dense = [cell(0.01, 9.99, 1), cell(0.02, 9.98, 1), cell(0.03, 9.97, 1)];
+
+    expect(rasterizeCells(dense, bounds, 100, 100, 20)).toHaveLength(1);
+  });
+
+  it("keeps cells in different grid squares apart", () => {
+    const spread = [cell(0, 10, 1), cell(10, 0, 1)];
+
+    expect(rasterizeCells(spread, bounds, 100, 100, 20)).toHaveLength(2);
+  });
+
+  it("sums the hits inside a square so busy areas stay hottest", () => {
+    // Fire spredte enkeltturer mot én rute som er løpt tre ganger: summering
+    // gjør at området med mest løping vinner, ikke cellen med høyest enkelttall.
+    const cells = [
+      cell(0.01, 9.99, 1),
+      cell(0.02, 9.98, 1),
+      cell(0.03, 9.97, 1),
+      cell(0.04, 9.96, 1),
+      cell(9.99, 0.01, 3),
+    ];
+    const [busy, single] = rasterizeCells(cells, bounds, 100, 100, 20);
+
+    expect(busy.weight).toBe(1);
+    expect(single.weight).toBeLessThan(1);
+  });
+
+  it("snaps each square to its own centre", () => {
+    const [point] = rasterizeCells([cell(0.01, 9.99, 1)], bounds, 100, 100, 20);
+
+    expect(point.x).toBe(10);
+    expect(point.y).toBe(10);
+  });
+
+  it("falls back to per-cell projection when the grid is disabled", () => {
+    const cells = [cell(0.01, 9.99, 1), cell(0.02, 9.98, 1)];
+
+    expect(rasterizeCells(cells, bounds, 100, 100, 0)).toEqual(
+      projectCells(cells, bounds, 100, 100),
+    );
+  });
+
+  it("survives an empty dataset", () => {
+    expect(rasterizeCells([], bounds, 100, 100, 20)).toEqual([]);
   });
 });

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -57,6 +57,122 @@ export function toHeatmapGeoJson(cells: readonly HeatmapCell[]): HeatmapFeatureC
   };
 }
 
+/**
+ * Ruteinndelingen klyngene bygges av. En rute er omtrent 25 km på våre breddegrader.
+ *
+ * Stort nok til at løpeturene i én by havner i samme klynge selv med hull mellom
+ * dem, lite nok til at to byer aldri smelter sammen. Verdien er grov med vilje:
+ * skillet vi trenger å se er by mot by, ikke bydel mot bydel.
+ */
+const CLUSTER_BIN_DEGREES = 0.25;
+
+const clusterKey = (lon: number, lat: number) =>
+  `${Math.floor(lon / CLUSTER_BIN_DEGREES)}:${Math.floor(lat / CLUSTER_BIN_DEGREES)}`;
+
+/**
+ * Utstrekningen til den klyngen med flest treff.
+ *
+ * Aggregatet dekker alt jeg har løpt, også ferieturer. `bounds` fra backend
+ * spenner derfor fra Sør-Frankrike til Finland, og å åpne kartet på den gir et
+ * Europa-kart der Oslo er noen få piksler. Målt på ekte data ligger 86 % av
+ * treffene i Oslo og 9 % i den nest største klyngen, så vi åpner der løpingen
+ * faktisk er. Turene lenger unna ligger fortsatt i kartlaget og dukker opp om
+ * man zoomer ut.
+ *
+ * Persentil-trimming ble prøvd først og duger ikke: fordelingen er flere
+ * adskilte klynger, ikke en hale. Å kutte 5 % i hver ende beholdt fortsatt
+ * Frankrike.
+ *
+ * Returnerer `null` for et tomt datasett, slik at kalleren kan falle tilbake.
+ */
+export function dominantClusterBounds(cells: readonly HeatmapCell[]): HeatmapBounds | null {
+  if (cells.length === 0) return null;
+
+  const bins = new Map<string, { column: number; row: number; count: number }>();
+  for (const cell of cells) {
+    const column = Math.floor(cell.lon / CLUSTER_BIN_DEGREES);
+    const row = Math.floor(cell.lat / CLUSTER_BIN_DEGREES);
+    const key = `${column}:${row}`;
+    const existing = bins.get(key);
+    if (existing) {
+      existing.count += cell.count;
+      continue;
+    }
+    bins.set(key, { column, row, count: cell.count });
+  }
+
+  // Naboruter slås sammen i alle åtte retninger, så en klynge henger sammen selv
+  // når den krysser et rutehjørne på skrå.
+  const visited = new Set<string>();
+  let best: { keys: Set<string>; count: number } | null = null;
+
+  for (const [startKey, startBin] of bins) {
+    if (visited.has(startKey)) continue;
+
+    visited.add(startKey);
+    const stack = [startBin];
+    const keys = new Set<string>([startKey]);
+    let count = 0;
+
+    while (stack.length > 0) {
+      const bin = stack.pop();
+      if (!bin) break;
+      count += bin.count;
+
+      for (let dx = -1; dx <= 1; dx += 1) {
+        for (let dy = -1; dy <= 1; dy += 1) {
+          const neighbourKey = `${bin.column + dx}:${bin.row + dy}`;
+          if (visited.has(neighbourKey)) continue;
+          const neighbour = bins.get(neighbourKey);
+          if (!neighbour) continue;
+          visited.add(neighbourKey);
+          keys.add(neighbourKey);
+          stack.push(neighbour);
+        }
+      }
+    }
+
+    if (!best || count > best.count) best = { keys, count };
+  }
+
+  if (!best) return null;
+
+  // Utstrekningen leses av de faktiske cellene, ikke av rutekantene, slik at
+  // kartet åpner tett på løpingen framfor på et avrundet rutenett.
+  let west = Number.POSITIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let north = Number.NEGATIVE_INFINITY;
+
+  for (const cell of cells) {
+    if (!best.keys.has(clusterKey(cell.lon, cell.lat))) continue;
+    if (cell.lon < west) west = cell.lon;
+    if (cell.lon > east) east = cell.lon;
+    if (cell.lat < south) south = cell.lat;
+    if (cell.lat > north) north = cell.lat;
+  }
+
+  return [west, south, east, north];
+}
+
+/**
+ * Cellene som ligger innenfor en utstrekning.
+ *
+ * Teaseren tegner bare den dominerende klyngen, og `rasterizeCells` klemmer
+ * ruter utenfor flaten inn til kanten. Uten denne filtreringen ville turene i
+ * Frankrike lagt seg som falsk varme langs kanten av teaseren.
+ */
+export function cellsWithinBounds(
+  cells: readonly HeatmapCell[],
+  bounds: HeatmapBounds,
+): HeatmapCell[] {
+  const [west, south, east, north] = bounds;
+  return cells.filter(
+    (cell) =>
+      cell.lon >= west && cell.lon <= east && cell.lat >= south && cell.lat <= north,
+  );
+}
+
 // Web Mercator er udefinert på polene, så vi klipper til projeksjonens vanlige grense.
 const MAX_MERCATOR_LATITUDE = 85.051129;
 

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -144,10 +144,25 @@ export function rasterizeCells(
   const project = createProjection(bounds, width, height);
   const buckets = new Map<string, { x: number; y: number; count: number }>();
 
+  // Utstrekningen kommer fra cellene selv, så det finnes alltid en celle helt ute
+  // ved øst- og sørkanten. Den projiseres til presis `width`/`height`, og et rent
+  // `Math.floor` ville gitt den en egen rute utenfor tegneflaten. Ytterpunktet av
+  // varmekartet ble dermed klippet bort. Kanten hører til siste rute.
+  const lastColumn = Math.max(Math.ceil(width / pixelSize) - 1, 0);
+  const lastRow = Math.max(Math.ceil(height / pixelSize) - 1, 0);
+
+  // Ruten plasseres i sentrum av den delen som er synlig, ikke der den første
+  // cellen tilfeldigvis traff. Da legger punktene seg jevnt i rutenettet, og en
+  // siste rute som stikker utenfor flaten trekkes inn framfor å havne på kanten.
+  const center = (index: number, size: number) => {
+    const start = index * pixelSize;
+    return (start + Math.min(start + pixelSize, size)) / 2;
+  };
+
   for (const cell of cells) {
     const { x, y } = project(cell.lon, cell.lat);
-    const column = Math.floor(x / pixelSize);
-    const row = Math.floor(y / pixelSize);
+    const column = Math.min(Math.floor(x / pixelSize), lastColumn);
+    const row = Math.min(Math.floor(y / pixelSize), lastRow);
     const key = `${column}:${row}`;
     const existing = buckets.get(key);
 
@@ -156,11 +171,9 @@ export function rasterizeCells(
       continue;
     }
 
-    // Ruten plasseres i sitt eget sentrum, ikke der den første cellen tilfeldigvis
-    // traff, slik at punktene legger seg jevnt i rutenettet.
     buckets.set(key, {
-      x: (column + 0.5) * pixelSize,
-      y: (row + 0.5) * pixelSize,
+      x: center(column, width),
+      y: center(row, height),
       count: cell.count,
     });
   }

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -260,10 +260,15 @@ export function rasterizeCells(
   const project = createProjection(bounds, width, height);
   const buckets = new Map<string, { x: number; y: number; count: number }>();
 
-  // Utstrekningen kommer fra cellene selv, så det finnes alltid en celle helt ute
+  // Kommer utstrekningen fra cellene selv, finnes det alltid en celle helt ute
   // ved øst- og sørkanten. Den projiseres til presis `width`/`height`, og et rent
-  // `Math.floor` ville gitt den en egen rute utenfor tegneflaten. Ytterpunktet av
-  // varmekartet ble dermed klippet bort. Kanten hører til siste rute.
+  // `Math.floor` ville gitt den en egen rute utenfor tegneflaten.
+  //
+  // Klemmingen går begge veier. Kalles funksjonen med en utstrekning som er
+  // mindre enn dataene — slik teaseren gjør — havner celler også vest og nord
+  // for utsnittet, og de gir negative ruter. Kallere bør fortsatt filtrere med
+  // `cellsWithinBounds` for å slippe falsk varme langs kanten, men å tegne
+  // utenfor flaten skal ikke være mulig uansett hva som sendes inn.
   const lastColumn = Math.max(Math.ceil(width / pixelSize) - 1, 0);
   const lastRow = Math.max(Math.ceil(height / pixelSize) - 1, 0);
 
@@ -277,8 +282,8 @@ export function rasterizeCells(
 
   for (const cell of cells) {
     const { x, y } = project(cell.lon, cell.lat);
-    const column = Math.min(Math.floor(x / pixelSize), lastColumn);
-    const row = Math.min(Math.floor(y / pixelSize), lastRow);
+    const column = Math.min(Math.max(Math.floor(x / pixelSize), 0), lastColumn);
+    const row = Math.min(Math.max(Math.floor(y / pixelSize), 0), lastRow);
     const key = `${column}:${row}`;
     const existing = buckets.get(key);
 

--- a/lib/heatmap.ts
+++ b/lib/heatmap.ts
@@ -75,19 +75,14 @@ export type ProjectedCell = {
 };
 
 /**
- * Projiserer cellene inn i et SVG-koordinatsystem for den statiske teaseren.
- * Samme Web Mercator-projeksjon som kartbiblioteket bruker, slik at teaseren og
- * det interaktive kartet viser nøyaktig samme form.
+ * Bygger projeksjonen fra geografiske koordinater til et SVG-koordinatsystem.
+ * Samme Web Mercator som kartbiblioteket bruker, slik at teaseren og det
+ * interaktive kartet viser nøyaktig samme form.
  *
  * Målforholdet bevares og innholdet sentreres — strekker vi bildet for å fylle
  * viewBoxen blir byen visuelt feil.
  */
-export function projectCells(
-  cells: readonly HeatmapCell[],
-  bounds: HeatmapBounds,
-  width: number,
-  height: number,
-): ProjectedCell[] {
+function createProjection(bounds: HeatmapBounds, width: number, height: number) {
   const [west, south, east, north] = bounds;
   const originX = mercatorX(west);
   const originY = mercatorY(north);
@@ -103,11 +98,81 @@ export function projectCells(
 
   const offsetX = (width - spanX * safeScale) / 2;
   const offsetY = (height - spanY * safeScale) / 2;
+
+  return (lon: number, lat: number) => ({
+    x: offsetX + (mercatorX(lon) - originX) * safeScale,
+    y: offsetY + (mercatorY(lat) - originY) * safeScale,
+  });
+}
+
+/** Projiserer hver celle for seg, uten nedskalering. */
+export function projectCells(
+  cells: readonly HeatmapCell[],
+  bounds: HeatmapBounds,
+  width: number,
+  height: number,
+): ProjectedCell[] {
+  const project = createProjection(bounds, width, height);
   const maxCount = maxCellCount(cells);
 
-  return cells.map((cell) => ({
-    x: offsetX + (mercatorX(cell.lon) - originX) * safeScale,
-    y: offsetY + (mercatorY(cell.lat) - originY) * safeScale,
-    weight: normalizeWeight(cell.count, maxCount),
+  return cells.map((cell) => {
+    const { x, y } = project(cell.lon, cell.lat);
+    return { x, y, weight: normalizeWeight(cell.count, maxCount) };
+  });
+}
+
+/**
+ * Slår cellene sammen til et grovere rutenett før de tegnes.
+ *
+ * Aggregatet dekker et par mil med 15-meters celler, altså tusenvis av punkter.
+ * I den lille teaseren på forsiden er en celle uansett mindre enn én piksel, så
+ * å sende hver enkelt ville blåst opp HTML-en uten å legge til noe man kan se.
+ *
+ * Treffene summeres innenfor hver rute, ikke maksimeres: da måler ruten hvor
+ * mye løping som har skjedd i området, som er samme tetthetsbegrep kartlagets
+ * `heatmap`-modus bruker. Teaser og kart leser dermed likt.
+ */
+export function rasterizeCells(
+  cells: readonly HeatmapCell[],
+  bounds: HeatmapBounds,
+  width: number,
+  height: number,
+  pixelSize: number,
+): ProjectedCell[] {
+  if (pixelSize <= 0) return projectCells(cells, bounds, width, height);
+
+  const project = createProjection(bounds, width, height);
+  const buckets = new Map<string, { x: number; y: number; count: number }>();
+
+  for (const cell of cells) {
+    const { x, y } = project(cell.lon, cell.lat);
+    const column = Math.floor(x / pixelSize);
+    const row = Math.floor(y / pixelSize);
+    const key = `${column}:${row}`;
+    const existing = buckets.get(key);
+
+    if (existing) {
+      existing.count += cell.count;
+      continue;
+    }
+
+    // Ruten plasseres i sitt eget sentrum, ikke der den første cellen tilfeldigvis
+    // traff, slik at punktene legger seg jevnt i rutenettet.
+    buckets.set(key, {
+      x: (column + 0.5) * pixelSize,
+      y: (row + 0.5) * pixelSize,
+      count: cell.count,
+    });
+  }
+
+  let maxCount = 0;
+  for (const bucket of buckets.values()) {
+    if (bucket.count > maxCount) maxCount = bucket.count;
+  }
+
+  return Array.from(buckets.values(), (bucket) => ({
+    x: bucket.x,
+    y: bucket.y,
+    weight: normalizeWeight(bucket.count, maxCount),
   }));
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.26.0",
-    "maplibre-gl": "^6.0.0",
+    "maplibre-gl": "5.24.0",
     "next": "16.2.11",
     "next-view-transitions": "^0.3.5",
     "react": "19.2.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.26.0",
+    "maplibre-gl": "^6.0.0",
     "next": "16.2.11",
     "next-view-transitions": "^0.3.5",
     "react": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.26.0
         version: 1.26.0(react@19.2.8)
       maplibre-gl:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: 5.24.0
+        version: 5.24.0
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -481,17 +481,24 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@3.0.0':
-    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
 
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@26.2.1':
-    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -2055,8 +2062,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  maplibre-gl@6.0.0:
-    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   math-intrinsics@1.1.0:
@@ -2207,6 +2214,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
 
   pbf@5.1.2:
     resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
@@ -3048,19 +3059,23 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
+  '@mapbox/unitbezier@0.0.1': {}
+
   '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@3.0.0':
+  '@mapbox/vector-tile@2.0.5':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 5.1.2
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
 
   '@maplibre/geojson-vt@6.1.1':
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@26.2.1':
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -4582,14 +4597,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  maplibre-gl@6.0.0:
+  maplibre-gl@5.24.0:
     dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 1.0.0
-      '@mapbox/vector-tile': 3.0.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/whoots-js': 3.1.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 26.2.1
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -4597,7 +4614,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 5.1.2
+      pbf: 4.0.2
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
@@ -4752,6 +4769,10 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
 
   pbf@5.1.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       lucide-react:
         specifier: ^1.26.0
         version: 1.26.0(react@19.2.8)
+      maplibre-gl:
+        specifier: ^6.0.0
+        version: 6.0.0
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -468,6 +471,35 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -811,6 +843,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1402,6 +1437,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
@@ -1682,6 +1720,9 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1888,6 +1929,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -1900,6 +1944,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2008,6 +2055,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@6.0.0:
+    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2038,6 +2089,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
@@ -2154,6 +2208,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2177,6 +2235,9 @@ packages:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2184,12 +2245,18 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2218,6 +2285,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
@@ -2387,6 +2457,9 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -2969,6 +3042,43 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@3.0.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -3210,6 +3320,8 @@ snapshots:
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3728,6 +3840,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  earcut@3.2.3: {}
+
   electron-to-chromium@1.5.393: {}
 
   emoji-regex@9.2.2: {}
@@ -4167,6 +4281,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4365,6 +4481,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -4377,6 +4495,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4462,6 +4582,26 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@6.0.0:
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 5.1.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -4488,6 +4628,8 @@ snapshots:
   motion-utils@12.39.0: {}
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.16: {}
 
@@ -4611,6 +4753,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4631,6 +4777,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prop-types@15.8.1:
@@ -4639,9 +4787,13 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.1: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -4677,6 +4829,10 @@ snapshots:
       set-function-name: 2.0.2
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
 
   resolve@2.0.0-next.7:
     dependencies:
@@ -4920,6 +5076,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-export const API_BASE_URL = "https://api.vuhnger.dev";
+/**
+ * Kan peke et annet sted for å kjøre mot et lokalt API eller et mock-endepunkt,
+ * uten at koden endres. Uten variabelen går alt mot produksjon som før.
+ */
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.vuhnger.dev";
 const API_REVALIDATE_SECONDS = 5 * 60;
 const API_TIMEOUT_MS = 5_000;
 


### PR DESCRIPTION
Varmekart over løpeturene mine — egen side på `/running` pluss et lite kort på forsiden.

Alt ligger bak `RUNNING_HEATMAP_ENABLED`, som er av som standard. Ruten svarer 404 og kortet forsvinner fra forsiden når den ikke er satt, så dette kan merges uten at noe blir synlig før du selv skrur det på.

Kartet er MapLibre med et ekte `heatmap`-lag, ikke bilder eller streker. Fargene leses ut av designsystemets aksentvariabel i stedet for å hardkodes, og bakgrunnskartet bytter mellom lyst og mørkt sammen med resten av siden.

To ting som var mindre opplagte enn de ser ut:

`bounds` fra API-et dekker alt jeg har løpt, også ferier, så auto-fit ga et Europa-kart der Oslo var noen piksler. Kartet finner nå den tetteste klyngen og åpner der — 86 % av treffene ligger i Oslo. Turene i Frankrike og Finland ligger fortsatt i laget om man zoomer ut. Persentil-trimming ble prøvd først og duger ikke; fordelingen er flere adskilte klynger, ikke en hale.

`maplibre-gl` er låst til 5.24.0. 6.x utleder adressen til sin egen web worker fra `import.meta.url` og gir tom streng når den ikke er http(s). Etter Next-bundlingen er den ikke det, så workeren starter aldri og kartet blir stående tomt.

Teaseren er ren serverrendering — en SVG-punktsky uten en byte klientkode.
