### PR TITLE
chore: skann skills med SkillSpector i CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,28 @@ jobs:
             fi
           fi
 
+  skills:
+    name: Skill security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
+
+      # SkillSpector har ingen git-tagger, så pinningen må være en commit.
+      # Bumpen er bevisst manuell: en skanner som oppdaterer seg selv kan endre
+      # utfallet av en gate uten at noen har sett på diffen.
+      - name: Install SkillSpector
+        run: |
+          uv tool install \
+            'git+https://github.com/NVIDIA/skillspector.git@fd25398d7aa99353d86237b9c260759351f0e644'
+          uv tool dir --bin >> "$GITHUB_PATH"
+
+      - name: Scan skills
+        run: ./scripts/scan-skills.sh
+
   quality:
     name: Quality
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      # Full versjon, ikke `v9`: setup-uv publiserer ingen flyttbar major-tag.
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
 
       # SkillSpector har ingen git-tagger, så pinningen må være en commit.
       # Bumpen er bevisst manuell: en skanner som oppdaterer seg selv kan endre

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,11 @@ as the base branch.
 - Local Git hooks may provide faster feedback but are never a substitute for
   CI because hooks can be skipped. Add Semgrep only when a security or
   cross-file rule cannot be expressed reliably with the existing toolchain.
+- Every skill in `.opencode/skills` is scanned with SkillSpector by the
+  `Skill security` CI job. Run `./scripts/scan-skills.sh` locally after
+  changing a skill; it needs `skillspector` on `PATH`
+  (`uv tool install git+https://github.com/NVIDIA/skillspector.git`).
+- The job blocks on `DO_NOT_INSTALL` and reports `CAUTION` without failing.
+  Accept a reviewed false positive into `.skillspector-baseline.yaml` with
+  `skillspector baseline <skill> -o .skillspector-baseline.yaml` rather than
+  weakening the gate.

--- a/scripts/scan-skills.sh
+++ b/scripts/scan-skills.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Skanner hver skill i .opencode/skills med SkillSpector.
+#
+# Skills leses inn i agentens kontekst og kjøres med agentens rettigheter, uten
+# noen review-runde utover den som skjer i pull requesten. Denne skanningen er
+# den runden: den fanger prompt injection, eksfiltrering og andre mønstre som er
+# lette å overse i en markdown-fil som ellers ser ut som dokumentasjon.
+#
+# LLM-trinnet er skrudd av med vilje. Statisk analyse er deterministisk og
+# trenger ingen nøkkel, så den kan kjøres av hvem som helst og gir samme svar i
+# CI som lokalt.
+#
+set -euo pipefail
+
+SKILLS_DIR="${SKILLS_DIR:-.opencode/skills}"
+BASELINE_FILE="${BASELINE_FILE:-.skillspector-baseline.yaml}"
+
+if ! command -v skillspector >/dev/null 2>&1; then
+  echo "skillspector finnes ikke på PATH." >&2
+  echo "Installer den med: uv tool install git+https://github.com/NVIDIA/skillspector.git" >&2
+  exit 2
+fi
+
+scan_args=(--no-llm --format json)
+# Baselinen er valgfri. Uten den skannes alt fra scratch; med den rapporteres
+# bare nye funn, slik at en akseptert falsk positiv ikke blokkerer hver PR.
+if [ -f "$BASELINE_FILE" ]; then
+  scan_args+=(--baseline "$BASELINE_FILE")
+  echo "Bruker baseline: $BASELINE_FILE"
+fi
+
+report_dir="$(mktemp -d)"
+trap 'rm -rf "$report_dir"' EXIT
+
+blocked=0
+found_any=0
+
+for skill in "$SKILLS_DIR"/*/; do
+  [ -d "$skill" ] || continue
+  found_any=1
+  name="$(basename "$skill")"
+  report="$report_dir/$name.json"
+
+  # Skanneren avslutter med 1 når funnene er alvorlige nok til å blokkere. Det
+  # er ikke en feil her, så exit-koden fanges og avgjørelsen tas på rapporten.
+  set +e
+  skillspector scan "$skill" "${scan_args[@]}" --output "$report" >/dev/null
+  scan_status=$?
+  set -e
+
+  if [ ! -s "$report" ]; then
+    echo "FEIL      $name — skanningen produserte ingen rapport (exit $scan_status)"
+    blocked=1
+    continue
+  fi
+
+  verdict="$(
+    python3 - "$report" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    report = json.load(handle)
+
+risk = report.get("risk_assessment", {})
+issues = report.get("issues", [])
+print(
+    "{}\t{}\t{}\t{}".format(
+        risk.get("recommendation", "UKJENT"),
+        risk.get("score", "?"),
+        risk.get("severity", "?"),
+        len(issues),
+    )
+)
+PY
+  )"
+
+  IFS=$'\t' read -r recommendation score severity issue_count <<<"$verdict"
+
+  case "$recommendation" in
+    SAFE)
+      printf 'SAFE      %-28s %s/100 (%s)\n' "$name" "$score" "$severity"
+      ;;
+    CAUTION)
+      printf 'CAUTION   %-28s %s/100 (%s), %s funn\n' "$name" "$score" "$severity" "$issue_count"
+      skillspector scan "$skill" --no-llm >&2 || true
+      ;;
+    *)
+      printf 'BLOKKERT  %-28s %s/100 (%s), %s funn\n' "$name" "$score" "$severity" "$issue_count"
+      skillspector scan "$skill" --no-llm >&2 || true
+      blocked=1
+      ;;
+  esac
+done
+
+if [ "$found_any" -eq 0 ]; then
+  # Tom mappe er nesten alltid feil sti, ikke fravær av skills. Å melde grønt
+  # her ville gjort gaten stille ubrukelig.
+  echo "Fant ingen skills i $SKILLS_DIR." >&2
+  exit 2
+fi
+
+exit "$blocked"


### PR DESCRIPTION
Skills er egentlig kode vi kjører uten å lese nøye. De havner rett i agentens kontekst med agentens rettigheter, og den eneste reviewen de får er PR-en de kom inn i. NVIDIA sin [SkillSpector](https://github.com/NVIDIA/skillspector) leter etter prompt injection, eksfiltrering, privilege escalation og sånt i markdown som ellers ser ut som helt vanlig dokumentasjon — så nå kjører den som en egen CI-jobb.

`scripts/scan-skills.sh` går gjennom alt i `.opencode/skills`, blokkerer på `DO_NOT_INSTALL` og printer rapporten på `CAUTION` uten å felle bygget. Samme script kjører lokalt, så du får samme svar der som i CI.

LLM-trinnet er skrudd av med vilje: statisk analyse er deterministisk og trenger ingen API-nøkkel, så jobben funker for hvem som helst og gir ikke ulikt utfall fra kjøring til kjøring. Skanneren er pinnet til en commit siden repoet ikke har tagger — bumpen skal være noe man gjør bevisst, ikke noe som skjer under føttene på en gate.

Blir en falsk positiv til plage, er `.skillspector-baseline.yaml` veien, ikke å myke opp jobben.