### PR TITLE
Arkitekturgraf: siden tegner seg selv, og grensene håndheves

### DIFF
--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+import ArchitectureGraph from "@/components/architecture/ArchitectureGraph";
+
+export const metadata: Metadata = {
+  title: "Arkitektur",
+  description:
+    "Importgrafen til denne nettsiden, generert fra kildekoden. Viser hvilke filer som avhenger av hverandre, og hvilke av dem som havner i nettleserbunten.",
+};
+
+export default function ArchitecturePage() {
+  return (
+    <div
+      className="min-h-screen px-4 pt-20 pb-12"
+      style={{ backgroundColor: "var(--ds-color-neutral-background-default)" }}
+    >
+      <div className="mx-auto max-w-6xl">
+        <ArchitectureGraph />
+      </div>
+    </div>
+  );
+}

--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import ArchitectureGraph from "@/components/architecture/ArchitectureGraph";
+import GraphLegend from "@/components/architecture/GraphLegend";
 
 export const metadata: Metadata = {
   title: "Arkitektur",
@@ -15,6 +16,7 @@ export default function ArchitecturePage() {
       style={{ backgroundColor: "var(--ds-color-neutral-background-default)" }}
     >
       <div className="mx-auto max-w-6xl">
+        <GraphLegend />
         <ArchitectureGraph />
       </div>
     </div>

--- a/components/architecture/ArchitectureGraph.tsx
+++ b/components/architecture/ArchitectureGraph.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import graphData from "@/data/architecture-graph.json";
+import { LAYERS, buildArchitectureGraph, type ModuleRecord } from "@/lib/architecture";
+import {
+  createFrameTransform,
+  createSimulation,
+  settleSimulation,
+  stepSimulation,
+  transformX,
+  transformY,
+} from "@/lib/architecture-layout";
+
+import { useVisualizationEnvironment } from "@/components/visualization/useVisualizationEnvironment";
+import { BASE_SETTINGS, MOBILE_SETTINGS, REDUCED_SETTINGS } from "./graph/settings";
+
+/**
+ * Grafen leses inn her, i klientkomponenten, og ikke som props fra siden.
+ *
+ * AGENTS.md advarer mot å sende store statiske datastrukturer gjennom
+ * Client Component-props: da havner hele grafen i HTML-en som serialisert
+ * payload i tillegg til i bunten. Importert her ligger den bare i bunten.
+ *
+ * Konsekvensen er verdt å nevne: dette er grunnen til at `lib/architecture.ts`
+ * og `lib/architecture-layout.ts` selv står som klientfiler i grafen. Grafen
+ * viser altså sin egen visualisering.
+ */
+const modules = buildArchitectureGraph(graphData.modules as ModuleRecord[]).modules;
+
+/** Oppslag framfor indeks: simuleringsnodene skal ikke måtte ligge i samme rekkefølge. */
+const runtimeOf = new Map(modules.map((record) => [record.id, record.runtime]));
+
+/** Minsteradius 4, ikke 3: en node på 6 px i diameter er vanskelig å treffe med musa. */
+const nodeRadius = (inDegree: number) => 4 + Math.sqrt(inDegree) * 2.4;
+
+const ArchitectureGraph = () => {
+  const environment = useVisualizationEnvironment();
+  const settings = environment.reducedMotion
+    ? REDUCED_SETTINGS
+    : environment.mobile
+      ? MOBILE_SETTINGS
+      : BASE_SETTINGS;
+
+  const [active, setActive] = useState<string | null>(null);
+  /**
+   * Koordinatene settes bare på klienten, aldri i HTML-en.
+   *
+   * Layouten er deterministisk innenfor én JavaScript-motor, men `Math.cos` og
+   * `Math.sin` er ikke pålagt å gi bit-identiske svar på tvers av dem. Nodes V8
+   * og Chromes V8 ga 779.2369769141981 mot 779.236976914198, og React meldte
+   * hydration mismatch på hver linje og sirkel. Med 300 iterasjoner kan et
+   * avvik på siste bit dessuten vokse, så avrunding ville bare skjult det.
+   *
+   * Derfor står grafen usynlig til første posisjonsskriving. Lista under er ikke
+   * avhengig av dette og rendres som vanlig, så innhold går ikke tapt.
+   */
+  const [painted, setPainted] = useState(false);
+
+  const simulation = useMemo(() => {
+    const created = createSimulation(modules, settings.width, settings.height, settings);
+    // Uten animasjon skal grafen stå ferdig ved første maling, ikke falle til ro
+    // etterpå.
+    return settings.stepsPerFrame === 0 ? settleSimulation(created, settings) : created;
+  }, [settings]);
+
+  /** Kantene som node-indekser, så animasjonen slipper oppslag per ramme. */
+  const edgeIndices = useMemo(() => {
+    const indexOf = new Map(simulation.nodes.map((node, index) => [node.id, index]));
+    return simulation.edges.map((edge) => ({
+      from: indexOf.get(edge.from) ?? 0,
+      to: indexOf.get(edge.to) ?? 0,
+    }));
+  }, [simulation]);
+
+  /** Naboer i begge retninger, for å kunne markere alt en fil henger sammen med. */
+  const neighbours = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    const link = (from: string, to: string) => {
+      if (!map.has(from)) map.set(from, new Set());
+      map.get(from)?.add(to);
+    };
+    for (const edge of simulation.edges) {
+      link(edge.from, edge.to);
+      link(edge.to, edge.from);
+    }
+    return map;
+  }, [simulation]);
+
+  const nodeElements = useRef<(SVGCircleElement | null)[]>([]);
+  const labelElements = useRef<(SVGTextElement | null)[]>([]);
+  const edgeElements = useRef<(SVGLineElement | null)[]>([]);
+
+  useEffect(() => {
+    const writePositions = () => {
+      // Regnes ut på nytt hver ramme, så grafen fyller rammen hele veien mens den
+      // faller til ro - ikke bare når den er ferdig.
+      const frame = createFrameTransform(simulation, settings);
+      const screenX = (value: number) => transformX(frame, value);
+      const screenY = (value: number) => transformY(frame, value);
+
+      simulation.nodes.forEach((node, index) => {
+        const x = screenX(node.x);
+        const y = screenY(node.y);
+        nodeElements.current[index]?.setAttribute("cx", String(x));
+        nodeElements.current[index]?.setAttribute("cy", String(y));
+        labelElements.current[index]?.setAttribute("x", String(x));
+        labelElements.current[index]?.setAttribute(
+          "y",
+          String(y - nodeRadius(node.inDegree) - 4),
+        );
+      });
+
+      edgeIndices.forEach((edge, index) => {
+        const from = simulation.nodes[edge.from];
+        const to = simulation.nodes[edge.to];
+        const element = edgeElements.current[index];
+        if (!from || !to || !element) return;
+        element.setAttribute("x1", String(screenX(from.x)));
+        element.setAttribute("y1", String(screenY(from.y)));
+        element.setAttribute("x2", String(screenX(to.x)));
+        element.setAttribute("y2", String(screenY(to.y)));
+      });
+    };
+
+    writePositions();
+    setPainted(true);
+    if (settings.stepsPerFrame === 0) return;
+
+    let frame = requestAnimationFrame(function tick() {
+      for (let step = 0; step < settings.stepsPerFrame; step += 1) {
+        stepSimulation(simulation, settings);
+      }
+      writePositions();
+      // Stopper når grafen har falt til ro. Ingen evig animasjon å måtte skru av.
+      if (simulation.step < settings.iterations) frame = requestAnimationFrame(tick);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [edgeIndices, settings, simulation]);
+
+  const activeSet = useMemo(() => {
+    if (!active) return null;
+    return new Set([active, ...(neighbours.get(active) ?? [])]);
+  }, [active, neighbours]);
+
+  const clientCount = modules.filter((record) => record.runtime === "client").length;
+  const summary =
+    `Importgraf over kildekoden: ${modules.length} filer og ${simulation.edges.length} ` +
+    `avhengigheter. ${clientCount} filer havner i nettleserbunten, ` +
+    `${modules.length - clientCount} kjører bare på serveren.`;
+
+  return (
+    <div className="[--graph-edge:var(--ds-color-neutral-border-default)] [--graph-server:var(--ds-color-neutral-text-default)] [--graph-client:var(--ds-color-accent-base-default)] [--graph-label:var(--ds-color-neutral-text-default)]">
+      <svg
+        role="img"
+        aria-label={summary}
+        viewBox={`0 0 ${settings.width} ${settings.height}`}
+        className="h-auto w-full transition-opacity duration-300 motion-reduce:transition-none"
+        style={{ opacity: painted ? 1 : 0 }}
+      >
+        {simulation.edges.map((edge, index) => {
+          const highlighted =
+            activeSet !== null && (edge.from === active || edge.to === active);
+          return (
+            <line
+              key={`${edge.from}->${edge.to}`}
+              ref={(element) => {
+                edgeElements.current[index] = element;
+              }}
+              stroke={highlighted ? "var(--graph-client)" : "var(--graph-edge)"}
+              strokeOpacity={activeSet === null ? 0.28 : highlighted ? 0.9 : 0.08}
+              strokeWidth={highlighted ? 1.6 : 1}
+            />
+          );
+        })}
+
+        {simulation.nodes.map((node, index) => {
+          const dimmed = activeSet !== null && !activeSet.has(node.id);
+          const isClient = runtimeOf.get(node.id) === "client";
+          return (
+            <circle
+              key={node.id}
+              ref={(element) => {
+                nodeElements.current[index] = element;
+              }}
+              r={nodeRadius(node.inDegree)}
+              fill={isClient ? "var(--graph-client)" : "var(--graph-server)"}
+              fillOpacity={dimmed ? 0.15 : isClient ? 0.85 : 0.5}
+              stroke={isClient ? "var(--graph-client)" : "var(--graph-server)"}
+              strokeOpacity={dimmed ? 0.15 : 0.7}
+              strokeWidth={node.id === active ? 2.5 : 1}
+              // Hover direkte på grafen. Nodene får ikke tabindex: 83 tabstopp i
+              // en SVG er ubrukelig navigasjon. Tastaturveien går via lista under,
+              // som markerer den samme noden.
+              onMouseEnter={() => setActive(node.id)}
+              onMouseLeave={() => setActive(null)}
+              style={{ cursor: "pointer" }}
+            />
+          );
+        })}
+
+        {simulation.nodes.map((node, index) => {
+          const visible = node.id === active || node.inDegree >= settings.labelThreshold;
+          return (
+            <text
+              key={node.id}
+              ref={(element) => {
+                labelElements.current[index] = element;
+              }}
+              textAnchor="middle"
+              fill="var(--graph-label)"
+              fillOpacity={visible ? (node.id === active ? 1 : 0.65) : 0}
+              fontSize={node.id === active ? 13 : 11}
+              fontFamily="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+              fontWeight={node.id === active ? 700 : 500}
+            >
+              {node.id}
+            </text>
+          );
+        })}
+      </svg>
+
+      {/*
+        Listen er ikke pynt. SVG-en er `role="img"` med en oppsummering, så den
+        forteller ikke en skjermleser hvilke filer som finnes - det gjør denne.
+        Den er samtidig tastaturinngangen til grafen: fokus på et element
+        markerer noden, slik at det å utforske grafen ikke krever mus.
+      */}
+      {/*
+        Kolonneflyt, ikke grid. Grid justerer radhøyder, så `app` med 15 filer sto
+        ved siden av `components` med 52 og etterlot 37 rader tomrom - siden ble
+        3043 px. Og maks to kolonner: tre ga under 200 px hver, og da overlappet
+        navn som `master/edge/NetworkControls.tsx` hverandre.
+      */}
+      <div className="mt-8 gap-10 md:columns-2">
+        {LAYERS.map((layer) => {
+          const inLayer = modules.filter((record) => record.layer === layer);
+          if (inLayer.length === 0) return null;
+          const clientsInLayer = inLayer.filter((record) => record.runtime === "client").length;
+
+          return (
+            <section key={layer} className="mb-6 inline-block w-full break-inside-avoid">
+              <h2
+                className="font-mono text-sm font-bold"
+                style={{ color: "var(--ds-color-accent-base-default)" }}
+              >
+                {layer}
+                <span
+                  className="ml-2 font-normal"
+                  style={{ color: "var(--ds-color-neutral-text-subtle)" }}
+                >
+                  {inLayer.length} · {clientsInLayer} klient
+                </span>
+              </h2>
+              <ul className="mt-2 space-y-0.5">
+                {inLayer.map((record) => (
+                  <li key={record.id}>
+                    <button
+                      type="button"
+                      onMouseEnter={() => setActive(record.id)}
+                      onMouseLeave={() => setActive(null)}
+                      onFocus={() => setActive(record.id)}
+                      onBlur={() => setActive(null)}
+                      className="w-full rounded px-1 text-left font-mono text-xs transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+                      style={{
+                        color:
+                          record.runtime === "client"
+                            ? "var(--ds-color-accent-base-default)"
+                            : "var(--ds-color-neutral-text-subtle)",
+                        backgroundColor:
+                          active === record.id
+                            ? "var(--ds-color-accent-surface-tinted)"
+                            : "transparent",
+                        outlineColor: "var(--ds-color-accent-base-default)",
+                      }}
+                    >
+                      {record.id.slice(layer.length + 1)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ArchitectureGraph;

--- a/components/architecture/ArchitectureGraph.tsx
+++ b/components/architecture/ArchitectureGraph.tsx
@@ -1,40 +1,24 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-
-import graphData from "@/data/architecture-graph.json";
-import { LAYERS, buildArchitectureGraph, type ModuleRecord } from "@/lib/architecture";
-import {
-  createFrameTransform,
-  createSimulation,
-  settleSimulation,
-  stepSimulation,
-  transformX,
-  transformY,
-} from "@/lib/architecture-layout";
-
 import { useVisualizationEnvironment } from "@/components/visualization/useVisualizationEnvironment";
+
+import { ARCHITECTURE_MODULES, RUNTIME_OF } from "./graph/data";
+import GraphEdges from "./graph/GraphEdges";
+import GraphLabels from "./graph/GraphLabels";
+import GraphNodes from "./graph/GraphNodes";
 import { BASE_SETTINGS, MOBILE_SETTINGS, REDUCED_SETTINGS } from "./graph/settings";
+import { describeGraph } from "./graph/summary";
+import { useActiveNode } from "./graph/useActiveNode";
+import { useGraphLayout } from "./graph/useGraphLayout";
 
 /**
- * Grafen leses inn her, i klientkomponenten, og ikke som props fra siden.
+ * Importgrafen til denne kodebasen, tegnet av seg selv.
  *
- * AGENTS.md advarer mot å sende store statiske datastrukturer gjennom
- * Client Component-props: da havner hele grafen i HTML-en som serialisert
- * payload i tillegg til i bunten. Importert her ligger den bare i bunten.
- *
- * Konsekvensen er verdt å nevne: dette er grunnen til at `lib/architecture.ts`
- * og `lib/architecture-layout.ts` selv står som klientfiler i grafen. Grafen
- * viser altså sin egen visualisering.
+ * Komponenten setter bare sammen delene: `useGraphLayout` regner ut og skriver
+ * posisjoner, `useActiveNode` holder hva som er markert, og de tre
+ * underkomponentene rendrer kanter, noder og navn. Tegnforklaringen ligger i
+ * `GraphLegend`, som er en serverkomponent.
  */
-const modules = buildArchitectureGraph(graphData.modules as ModuleRecord[]).modules;
-
-/** Oppslag framfor indeks: simuleringsnodene skal ikke måtte ligge i samme rekkefølge. */
-const runtimeOf = new Map(modules.map((record) => [record.id, record.runtime]));
-
-/** Minsteradius 4, ikke 3: en node på 6 px i diameter er vanskelig å treffe med musa. */
-const nodeRadius = (inDegree: number) => 4 + Math.sqrt(inDegree) * 2.4;
-
 const ArchitectureGraph = () => {
   const environment = useVisualizationEnvironment();
   const settings = environment.reducedMotion
@@ -43,249 +27,38 @@ const ArchitectureGraph = () => {
       ? MOBILE_SETTINGS
       : BASE_SETTINGS;
 
-  const [active, setActive] = useState<string | null>(null);
-  /**
-   * Koordinatene settes bare på klienten, aldri i HTML-en.
-   *
-   * Layouten er deterministisk innenfor én JavaScript-motor, men `Math.cos` og
-   * `Math.sin` er ikke pålagt å gi bit-identiske svar på tvers av dem. Nodes V8
-   * og Chromes V8 ga 779.2369769141981 mot 779.236976914198, og React meldte
-   * hydration mismatch på hver linje og sirkel. Med 300 iterasjoner kan et
-   * avvik på siste bit dessuten vokse, så avrunding ville bare skjult det.
-   *
-   * Derfor står grafen usynlig til første posisjonsskriving. Lista under er ikke
-   * avhengig av dette og rendres som vanlig, så innhold går ikke tapt.
-   */
-  const [painted, setPainted] = useState(false);
-
-  const simulation = useMemo(() => {
-    const created = createSimulation(modules, settings.width, settings.height, settings);
-    // Uten animasjon skal grafen stå ferdig ved første maling, ikke falle til ro
-    // etterpå.
-    return settings.stepsPerFrame === 0 ? settleSimulation(created, settings) : created;
-  }, [settings]);
-
-  /** Kantene som node-indekser, så animasjonen slipper oppslag per ramme. */
-  const edgeIndices = useMemo(() => {
-    const indexOf = new Map(simulation.nodes.map((node, index) => [node.id, index]));
-    return simulation.edges.map((edge) => ({
-      from: indexOf.get(edge.from) ?? 0,
-      to: indexOf.get(edge.to) ?? 0,
-    }));
-  }, [simulation]);
-
-  /** Naboer i begge retninger, for å kunne markere alt en fil henger sammen med. */
-  const neighbours = useMemo(() => {
-    const map = new Map<string, Set<string>>();
-    const link = (from: string, to: string) => {
-      if (!map.has(from)) map.set(from, new Set());
-      map.get(from)?.add(to);
-    };
-    for (const edge of simulation.edges) {
-      link(edge.from, edge.to);
-      link(edge.to, edge.from);
-    }
-    return map;
-  }, [simulation]);
-
-  const nodeElements = useRef<(SVGCircleElement | null)[]>([]);
-  const labelElements = useRef<(SVGTextElement | null)[]>([]);
-  const edgeElements = useRef<(SVGLineElement | null)[]>([]);
-
-  useEffect(() => {
-    const writePositions = () => {
-      // Regnes ut på nytt hver ramme, så grafen fyller rammen hele veien mens den
-      // faller til ro - ikke bare når den er ferdig.
-      const frame = createFrameTransform(simulation, settings);
-      const screenX = (value: number) => transformX(frame, value);
-      const screenY = (value: number) => transformY(frame, value);
-
-      simulation.nodes.forEach((node, index) => {
-        const x = screenX(node.x);
-        const y = screenY(node.y);
-        nodeElements.current[index]?.setAttribute("cx", String(x));
-        nodeElements.current[index]?.setAttribute("cy", String(y));
-        labelElements.current[index]?.setAttribute("x", String(x));
-        labelElements.current[index]?.setAttribute(
-          "y",
-          String(y - nodeRadius(node.inDegree) - 4),
-        );
-      });
-
-      edgeIndices.forEach((edge, index) => {
-        const from = simulation.nodes[edge.from];
-        const to = simulation.nodes[edge.to];
-        const element = edgeElements.current[index];
-        if (!from || !to || !element) return;
-        element.setAttribute("x1", String(screenX(from.x)));
-        element.setAttribute("y1", String(screenY(from.y)));
-        element.setAttribute("x2", String(screenX(to.x)));
-        element.setAttribute("y2", String(screenY(to.y)));
-      });
-    };
-
-    writePositions();
-    setPainted(true);
-    if (settings.stepsPerFrame === 0) return;
-
-    let frame = requestAnimationFrame(function tick() {
-      for (let step = 0; step < settings.stepsPerFrame; step += 1) {
-        stepSimulation(simulation, settings);
-      }
-      writePositions();
-      // Stopper når grafen har falt til ro. Ingen evig animasjon å måtte skru av.
-      if (simulation.step < settings.iterations) frame = requestAnimationFrame(tick);
-    });
-
-    return () => cancelAnimationFrame(frame);
-  }, [edgeIndices, settings, simulation]);
-
-  const activeSet = useMemo(() => {
-    if (!active) return null;
-    return new Set([active, ...(neighbours.get(active) ?? [])]);
-  }, [active, neighbours]);
-
-  const clientCount = modules.filter((record) => record.runtime === "client").length;
-  const summary =
-    `Importgraf over kildekoden: ${modules.length} filer og ${simulation.edges.length} ` +
-    `avhengigheter. ${clientCount} filer havner i nettleserbunten, ` +
-    `${modules.length - clientCount} kjører bare på serveren.`;
+  const { simulation, elements, painted } = useGraphLayout(ARCHITECTURE_MODULES, settings);
+  const { active, activeSet, setActive } = useActiveNode(simulation.edges);
 
   return (
-    <div className="[--graph-edge:var(--ds-color-neutral-border-default)] [--graph-server:var(--ds-color-neutral-text-default)] [--graph-client:var(--ds-color-accent-base-default)] [--graph-label:var(--ds-color-neutral-text-default)]">
-      <svg
-        role="img"
-        aria-label={summary}
-        viewBox={`0 0 ${settings.width} ${settings.height}`}
-        className="h-auto w-full transition-opacity duration-300 motion-reduce:transition-none"
-        style={{ opacity: painted ? 1 : 0 }}
-      >
-        {simulation.edges.map((edge, index) => {
-          const highlighted =
-            activeSet !== null && (edge.from === active || edge.to === active);
-          return (
-            <line
-              key={`${edge.from}->${edge.to}`}
-              ref={(element) => {
-                edgeElements.current[index] = element;
-              }}
-              stroke={highlighted ? "var(--graph-client)" : "var(--graph-edge)"}
-              strokeOpacity={activeSet === null ? 0.28 : highlighted ? 0.9 : 0.08}
-              strokeWidth={highlighted ? 1.6 : 1}
-            />
-          );
-        })}
-
-        {simulation.nodes.map((node, index) => {
-          const dimmed = activeSet !== null && !activeSet.has(node.id);
-          const isClient = runtimeOf.get(node.id) === "client";
-          return (
-            <circle
-              key={node.id}
-              ref={(element) => {
-                nodeElements.current[index] = element;
-              }}
-              r={nodeRadius(node.inDegree)}
-              fill={isClient ? "var(--graph-client)" : "var(--graph-server)"}
-              fillOpacity={dimmed ? 0.15 : isClient ? 0.85 : 0.5}
-              stroke={isClient ? "var(--graph-client)" : "var(--graph-server)"}
-              strokeOpacity={dimmed ? 0.15 : 0.7}
-              strokeWidth={node.id === active ? 2.5 : 1}
-              // Hover direkte på grafen. Nodene får ikke tabindex: 83 tabstopp i
-              // en SVG er ubrukelig navigasjon. Tastaturveien går via lista under,
-              // som markerer den samme noden.
-              onMouseEnter={() => setActive(node.id)}
-              onMouseLeave={() => setActive(null)}
-              style={{ cursor: "pointer" }}
-            />
-          );
-        })}
-
-        {simulation.nodes.map((node, index) => {
-          const visible = node.id === active || node.inDegree >= settings.labelThreshold;
-          return (
-            <text
-              key={node.id}
-              ref={(element) => {
-                labelElements.current[index] = element;
-              }}
-              textAnchor="middle"
-              fill="var(--graph-label)"
-              fillOpacity={visible ? (node.id === active ? 1 : 0.65) : 0}
-              fontSize={node.id === active ? 13 : 11}
-              fontFamily="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
-              fontWeight={node.id === active ? 700 : 500}
-            >
-              {node.id}
-            </text>
-          );
-        })}
-      </svg>
-
-      {/*
-        Listen er ikke pynt. SVG-en er `role="img"` med en oppsummering, så den
-        forteller ikke en skjermleser hvilke filer som finnes - det gjør denne.
-        Den er samtidig tastaturinngangen til grafen: fokus på et element
-        markerer noden, slik at det å utforske grafen ikke krever mus.
-      */}
-      {/*
-        Kolonneflyt, ikke grid. Grid justerer radhøyder, så `app` med 15 filer sto
-        ved siden av `components` med 52 og etterlot 37 rader tomrom - siden ble
-        3043 px. Og maks to kolonner: tre ga under 200 px hver, og da overlappet
-        navn som `master/edge/NetworkControls.tsx` hverandre.
-      */}
-      <div className="mt-8 gap-10 md:columns-2">
-        {LAYERS.map((layer) => {
-          const inLayer = modules.filter((record) => record.layer === layer);
-          if (inLayer.length === 0) return null;
-          const clientsInLayer = inLayer.filter((record) => record.runtime === "client").length;
-
-          return (
-            <section key={layer} className="mb-6 inline-block w-full break-inside-avoid">
-              <h2
-                className="font-mono text-sm font-bold"
-                style={{ color: "var(--ds-color-accent-base-default)" }}
-              >
-                {layer}
-                <span
-                  className="ml-2 font-normal"
-                  style={{ color: "var(--ds-color-neutral-text-subtle)" }}
-                >
-                  {inLayer.length} · {clientsInLayer} klient
-                </span>
-              </h2>
-              <ul className="mt-2 space-y-0.5">
-                {inLayer.map((record) => (
-                  <li key={record.id}>
-                    <button
-                      type="button"
-                      onMouseEnter={() => setActive(record.id)}
-                      onMouseLeave={() => setActive(null)}
-                      onFocus={() => setActive(record.id)}
-                      onBlur={() => setActive(null)}
-                      className="w-full rounded px-1 text-left font-mono text-xs transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
-                      style={{
-                        color:
-                          record.runtime === "client"
-                            ? "var(--ds-color-accent-base-default)"
-                            : "var(--ds-color-neutral-text-subtle)",
-                        backgroundColor:
-                          active === record.id
-                            ? "var(--ds-color-accent-surface-tinted)"
-                            : "transparent",
-                        outlineColor: "var(--ds-color-accent-base-default)",
-                      }}
-                    >
-                      {record.id.slice(layer.length + 1)}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          );
-        })}
-      </div>
-    </div>
+    <svg
+      role="img"
+      aria-label={describeGraph(ARCHITECTURE_MODULES, simulation.edges.length)}
+      viewBox={`0 0 ${settings.width} ${settings.height}`}
+      className="h-auto w-full transition-opacity duration-300 motion-reduce:transition-none"
+      style={{ opacity: painted ? 1 : 0 }}
+    >
+      <GraphEdges
+        edges={simulation.edges}
+        elements={elements}
+        active={active}
+        hasActive={activeSet !== null}
+      />
+      <GraphNodes
+        nodes={simulation.nodes}
+        runtimeOf={RUNTIME_OF}
+        elements={elements}
+        active={active}
+        activeSet={activeSet}
+        onActivate={setActive}
+      />
+      <GraphLabels
+        nodes={simulation.nodes}
+        elements={elements}
+        active={active}
+        labelThreshold={settings.labelThreshold}
+      />
+    </svg>
   );
 };
 

--- a/components/architecture/GraphLegend.tsx
+++ b/components/architecture/GraphLegend.tsx
@@ -1,0 +1,108 @@
+import { LAYERS } from "@/lib/architecture";
+
+import { EDGE_COLOR, LAYER_FILL, LAYER_STROKE } from "./graph/colors";
+import { ARCHITECTURE_MODULES as modules } from "./graph/data";
+
+/**
+ * Tegnforklaring for arkitekturgrafen.
+ *
+ * Serverkomponent: innholdet er statisk, så det rendres på serveren og ligger
+ * utenfor klientbunten. Tallene kommer fra den samme utledede grafen som figuren
+ * bruker, så forklaringen kan ikke komme i utakt med det den forklarer.
+ *
+ * Den står over grafen og ikke under, fordi en fargekode må være lest før man
+ * ser på figuren for å ha noen verdi.
+ */
+const perLayer = LAYERS.map((layer) => ({
+  layer,
+  count: modules.filter((record) => record.layer === layer).length,
+})).filter((entry) => entry.count > 0);
+
+const clientCount = modules.filter((record) => record.runtime === "client").length;
+
+/** Samme filtrering som layouten gjør: bare kanter mellom filer som er skannet. */
+const known = new Set(modules.map((record) => record.id));
+const edgeCount = modules.reduce(
+  (total, record) =>
+    total + record.imports.filter((dependency) => known.has(dependency)).length,
+  0,
+);
+
+const SUBTLE = "var(--ds-color-neutral-text-subtle)";
+
+const GraphLegend = () => (
+  <div className="mb-6 flex flex-col gap-3 text-xs">
+    <ul className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      {perLayer.map(({ layer, count }) => (
+        <li key={layer} className="flex items-center gap-1.5">
+          {/* Fyll og omriss som i grafen, ikke bare fyllet: prikken skal se ut
+              som nodene den forklarer. */}
+          <span
+            aria-hidden="true"
+            className="size-3 shrink-0 rounded-full border-[1.5px]"
+            style={{
+              backgroundColor: LAYER_FILL[layer],
+              borderColor: LAYER_STROKE[layer],
+            }}
+          />
+          <span className="font-mono font-medium">{layer}/</span>
+          <span style={{ color: SUBTLE }}>{count}</span>
+        </li>
+      ))}
+    </ul>
+
+    <ul className="flex flex-wrap items-center gap-x-5 gap-y-2" style={{ color: SUBTLE }}>
+      <li className="flex items-center gap-1.5">
+        <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12">
+          <circle cx="6" cy="6" r="5" fill="currentColor" fillOpacity="0.85" />
+        </svg>
+        fylt: havner i nettleseren ({clientCount})
+      </li>
+      <li className="flex items-center gap-1.5">
+        <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12">
+          <circle cx="6" cy="6" r="4.4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+        åpen: bare server ({modules.length - clientCount})
+      </li>
+      <li className="flex items-center gap-1.5">
+        {/* Pilspiss også her, for retningen er hele poenget: hvem importerer hvem. */}
+        <svg aria-hidden="true" width="38" height="12" viewBox="0 0 38 12">
+          <defs>
+            <marker
+              id="legend-arrow"
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M0,0 L8,4 L0,8 z" fill={EDGE_COLOR} />
+            </marker>
+          </defs>
+          <circle cx="3" cy="6" r="2.5" fill="currentColor" />
+          <line
+            x1="7"
+            y1="6"
+            x2="27"
+            y2="6"
+            stroke={EDGE_COLOR}
+            strokeWidth="1.2"
+            markerEnd="url(#legend-arrow)"
+          />
+          <circle cx="34" cy="6" r="2.5" fill="currentColor" />
+        </svg>
+        pil: importerer den den peker på ({edgeCount})
+      </li>
+      <li className="flex items-center gap-1.5">
+        <svg aria-hidden="true" width="26" height="12" viewBox="0 0 26 12">
+          <circle cx="4" cy="6" r="3" fill="currentColor" fillOpacity="0.85" />
+          <circle cx="17" cy="6" r="6" fill="currentColor" fillOpacity="0.85" />
+        </svg>
+        størrelse: antall filer som importerer den
+      </li>
+    </ul>
+  </div>
+);
+
+export default GraphLegend;

--- a/components/architecture/graph/GraphEdges.tsx
+++ b/components/architecture/graph/GraphEdges.tsx
@@ -60,7 +60,7 @@ const GraphEdges = ({ edges, elements, active, hasActive }: Props) => (
           stroke={highlighted ? EDGE_ACTIVE_COLOR : EDGE_COLOR}
           strokeOpacity={!hasActive ? 0.32 : highlighted ? 0.9 : 0.07}
           strokeWidth={highlighted ? 1.6 : 1}
-          // Dempede kanter mister pilspissen: 132 piler mens noe annet er
+          // Dempede kanter mister pilspissen: 127 piler mens noe annet er
           // markert er bare støy.
           markerEnd={
             dimmed

--- a/components/architecture/graph/GraphEdges.tsx
+++ b/components/architecture/graph/GraphEdges.tsx
@@ -1,0 +1,76 @@
+import type { LayoutEdge } from "@/lib/architecture-layout";
+
+import { EDGE_ACTIVE_COLOR, EDGE_COLOR } from "./colors";
+import type { GraphElements } from "./useGraphLayout";
+
+/**
+ * Pilspissene er egne markører og ikke `context-stroke`, som ikke er støttet
+ * bredt nok ennå. `userSpaceOnUse` gjør at spissen har samme størrelse uansett
+ * strektykkelse, så en markert kant ikke får en uforholdsmessig stor pil.
+ */
+const ArrowHeads = () => (
+  <defs>
+    <marker
+      id="graph-arrow"
+      viewBox="0 0 8 8"
+      refX="7"
+      refY="4"
+      markerWidth="7"
+      markerHeight="7"
+      markerUnits="userSpaceOnUse"
+      orient="auto"
+    >
+      <path d="M0,0 L8,4 L0,8 z" fill={EDGE_COLOR} fillOpacity="0.55" />
+    </marker>
+    <marker
+      id="graph-arrow-active"
+      viewBox="0 0 8 8"
+      refX="7"
+      refY="4"
+      markerWidth="9"
+      markerHeight="9"
+      markerUnits="userSpaceOnUse"
+      orient="auto"
+    >
+      <path d="M0,0 L8,4 L0,8 z" fill={EDGE_ACTIVE_COLOR} />
+    </marker>
+  </defs>
+);
+
+type Props = {
+  edges: readonly LayoutEdge[];
+  elements: GraphElements;
+  active: string | null;
+  hasActive: boolean;
+};
+
+/** Kantene. Koordinatene skrives av `useGraphLayout`, ikke her. */
+const GraphEdges = ({ edges, elements, active, hasActive }: Props) => (
+  <>
+    <ArrowHeads />
+    {edges.map((edge, index) => {
+      const highlighted = hasActive && (edge.from === active || edge.to === active);
+      const dimmed = hasActive && !highlighted;
+      return (
+        <line
+          key={`${edge.from}->${edge.to}`}
+          ref={(element) => {
+            elements.edges.current[index] = element;
+          }}
+          stroke={highlighted ? EDGE_ACTIVE_COLOR : EDGE_COLOR}
+          strokeOpacity={!hasActive ? 0.32 : highlighted ? 0.9 : 0.07}
+          strokeWidth={highlighted ? 1.6 : 1}
+          // Dempede kanter mister pilspissen: 132 piler mens noe annet er
+          // markert er bare støy.
+          markerEnd={
+            dimmed
+              ? undefined
+              : `url(#${highlighted ? "graph-arrow-active" : "graph-arrow"})`
+          }
+        />
+      );
+    })}
+  </>
+);
+
+export default GraphEdges;

--- a/components/architecture/graph/GraphLabels.tsx
+++ b/components/architecture/graph/GraphLabels.tsx
@@ -1,0 +1,57 @@
+import type { LayoutNode } from "@/lib/architecture-layout";
+
+import { LABEL_COLOR } from "./colors";
+import type { GraphElements } from "./useGraphLayout";
+
+const MONOSPACE = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
+
+type Props = {
+  nodes: readonly LayoutNode[];
+  elements: GraphElements;
+  active: string | null;
+  /** Filer med minst så mange importører viser navnet sitt uten hover. */
+  labelThreshold: number;
+};
+
+/**
+ * Filnavnene.
+ *
+ * Alle navnene rendres alltid, og de som ikke skal synes står med opacity 0.
+ * Alternativet - å montere og avmontere tekst ved hover - ville gjort at
+ * `useGraphLayout` skrev posisjoner til elementer som ikke fantes.
+ */
+const GraphLabels = ({ nodes, elements, active, labelThreshold }: Props) => (
+  <>
+    {nodes.map((node, index) => {
+      const visible = node.id === active || node.inDegree >= labelThreshold;
+      return (
+        <text
+          key={node.id}
+          ref={(element) => {
+            elements.labels.current[index] = element;
+          }}
+          textAnchor="middle"
+          fill={LABEL_COLOR}
+          // Glorie i bakgrunnsfargen. Uten den leses navnene rett oppå noder og
+          // streker, og en tett graf har ingen tomme flater å legge tekst i.
+          // `paint-order` gjør at omrisset males under bokstavene, ikke over.
+          stroke="var(--ds-color-neutral-background-default)"
+          strokeWidth={3}
+          strokeLinejoin="round"
+          paintOrder="stroke"
+          // Må settes eksplisitt: `fill-opacity` gjelder ikke omrisset, så uten
+          // dette malte glorien til alle de skjulte navnene hull i nodene under.
+          strokeOpacity={visible ? 1 : 0}
+          fillOpacity={visible ? (node.id === active ? 1 : 0.65) : 0}
+          fontSize={node.id === active ? 13 : 11}
+          fontFamily={MONOSPACE}
+          fontWeight={node.id === active ? 700 : 500}
+        >
+          {node.id}
+        </text>
+      );
+    })}
+  </>
+);
+
+export default GraphLabels;

--- a/components/architecture/graph/GraphNodes.tsx
+++ b/components/architecture/graph/GraphNodes.tsx
@@ -1,0 +1,59 @@
+import type { Runtime } from "@/lib/architecture";
+import type { LayoutNode } from "@/lib/architecture-layout";
+
+import { LAYER_FILL, LAYER_STROKE } from "./colors";
+import { nodeRadius } from "./summary";
+import type { GraphElements } from "./useGraphLayout";
+
+type Props = {
+  nodes: readonly LayoutNode[];
+  runtimeOf: ReadonlyMap<string, Runtime>;
+  elements: GraphElements;
+  active: string | null;
+  activeSet: ReadonlySet<string> | null;
+  onActivate: (id: string | null) => void;
+};
+
+/** Nodene. Koordinatene skrives av `useGraphLayout`, ikke her. */
+const GraphNodes = ({
+  nodes,
+  runtimeOf,
+  elements,
+  active,
+  activeSet,
+  onActivate,
+}: Props) => (
+  <>
+    {nodes.map((node, index) => {
+      const dimmed = activeSet !== null && !activeSet.has(node.id);
+      const isClient = runtimeOf.get(node.id) === "client";
+      return (
+        <circle
+          key={node.id}
+          ref={(element) => {
+            elements.nodes.current[index] = element;
+          }}
+          r={nodeRadius(node.inDegree)}
+          // Farge sier hvilket lag filen ligger i, fylt eller åpen sier om den
+          // havner i nettleseren. To kanaler, så ingen av dem trenger å bære to
+          // betydninger samtidig.
+          fill={isClient ? LAYER_FILL[node.layer] : "none"}
+          fillOpacity={0.9}
+          // Omrisset bærer kontrasten mot bakgrunnen, og er hele fargen på de
+          // åpne servernodene.
+          stroke={LAYER_STROKE[node.layer]}
+          strokeWidth={node.id === active ? 2.5 : isClient ? 1 : 1.8}
+          opacity={dimmed ? 0.18 : 1}
+          // Hover direkte på grafen. Nodene får ikke tabindex: 85 tabstopp i en
+          // SVG er ubrukelig navigasjon, og hover viser bare filnavnet, som ikke
+          // er informasjon `aria-label` mangler.
+          onMouseEnter={() => onActivate(node.id)}
+          onMouseLeave={() => onActivate(null)}
+          style={{ cursor: "pointer" }}
+        />
+      );
+    })}
+  </>
+);
+
+export default GraphNodes;

--- a/components/architecture/graph/colors.test.ts
+++ b/components/architecture/graph/colors.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { LAYERS, type Layer } from "../../../lib/architecture";
+import { LAYER_COLOR_FAMILIES } from "./colors";
+
+/**
+ * Fargene til grafen leses fra det bygde temaet, ikke fra komponenten.
+ *
+ * Bakgrunnen er en ekte feil: første versjon brukte `base-default`, og i mørkt
+ * tema havnet `lib` på 2,1:1 mot bakgrunnen. Det er under WCAG 1.4.11 sitt krav
+ * på 3:1 for grafikk som bærer informasjon, og det er ikke noe man ser i en
+ * kodegjennomgang - det må måles.
+ *
+ * Temaet er generert (`npx @digdir/designsystemet tokens build`), så det kan
+ * endre seg uten at noen rører denne mappa. Da er det denne testen som fanger
+ * det opp.
+ */
+const CSS = readFileSync(
+  join(process.cwd(), "design-tokens-build/portfolio.css"),
+  "utf8",
+);
+
+/** Temaet legger lyst først og mørkt bak `[data-color-scheme="dark"]`. */
+const DARK_MARKER = '[data-color-scheme="dark"]';
+const [lightBlock, darkBlock] = (() => {
+  const index = CSS.indexOf(DARK_MARKER);
+  if (index === -1) throw new Error(`Fant ikke ${DARK_MARKER} i temaet.`);
+  return [CSS.slice(0, index), CSS.slice(index)];
+})();
+
+function tokenValue(block: string, token: string): string {
+  const match = block.match(new RegExp(`--ds-color-${token}:\\s*(#[0-9a-fA-F]{6})`));
+  if (!match) throw new Error(`Fant ingen verdi for --ds-color-${token}.`);
+  return match[1];
+}
+
+/** WCAG relativ luminans. */
+function luminance(hex: string): number {
+  const channels = (hex.replace("#", "").match(/../g) ?? []).map((pair) => {
+    const value = parseInt(pair, 16) / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(first: string, second: string): number {
+  const [lighter, darker] = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Hue i grader. Brukes til å måle at to lagfarger ikke er nesten like. */
+function hue(hex: string): number {
+  const [red, green, blue] = (hex.replace("#", "").match(/../g) ?? []).map(
+    (pair) => parseInt(pair, 16) / 255,
+  );
+  const max = Math.max(red, green, blue);
+  const span = max - Math.min(red, green, blue);
+  if (span === 0) return 0;
+  const sector =
+    max === red
+      ? ((green - blue) / span) % 6
+      : max === green
+        ? (blue - red) / span + 2
+        : (red - green) / span + 4;
+  return ((sector * 60) + 360) % 360;
+}
+
+function hueDistance(first: string, second: string): number {
+  const difference = Math.abs(hue(first) - hue(second));
+  return Math.min(difference, 360 - difference);
+}
+
+const THEMES = [
+  { name: "lyst", block: lightBlock },
+  { name: "mørkt", block: darkBlock },
+];
+
+const layerToken = (block: string, layer: Layer, step: string) =>
+  tokenValue(block, `${LAYER_COLOR_FAMILIES[layer]}-${step}`);
+
+describe("lagfargene i arkitekturgrafen", () => {
+  it("dekker hvert lag", () => {
+    expect(Object.keys(LAYER_COLOR_FAMILIES).sort()).toEqual([...LAYERS].sort());
+  });
+
+  for (const theme of THEMES) {
+    it(`har nok kontrast på omrisset i ${theme.name} tema`, () => {
+      const background = tokenValue(theme.block, "neutral-background-default");
+
+      for (const layer of LAYERS) {
+        // Omrisset, ikke fyllet: en åpen servernode har bare omriss, og det er
+        // omrisset som holder de fylte nodene fra å forsvinne i bakgrunnen.
+        // 3:1 er WCAG 1.4.11 for grafikk som bærer informasjon.
+        expect(
+          contrast(layerToken(theme.block, layer, "border-strong"), background),
+          layer,
+        ).toBeGreaterThan(3);
+      }
+    });
+
+    it(`holder kulørene fra hverandre i ${theme.name} tema`, () => {
+      for (const first of LAYERS) {
+        for (const second of LAYERS) {
+          if (first >= second) continue;
+          // Fyllet, for det er den kulørte flaten øyet sorterer nodene etter.
+          // 25° er nok til å skille to farger; `brand2` mot `danger` lå på 25
+          // og var ikke til å skille, som er grunnen til at `app` bruker
+          // `warning`.
+          expect(
+            hueDistance(
+              layerToken(theme.block, first, "base-default"),
+              layerToken(theme.block, second, "base-default"),
+            ),
+            `${first} mot ${second}`,
+          ).toBeGreaterThan(25);
+        }
+      }
+    });
+  }
+});

--- a/components/architecture/graph/colors.ts
+++ b/components/architecture/graph/colors.ts
@@ -1,0 +1,59 @@
+// Bare typeimport. En verdiimport av `@/lib/architecture` her ville brutt
+// `colors.test.ts`, siden vitest i dette repoet ikke resolverer `@/`-aliaset.
+import type { Layer } from "@/lib/architecture";
+
+/**
+ * Én farge per lag, delt mellom grafen og tegnforklaringen.
+ *
+ * Hvert lag bruker to trinn av samme familie, og det er målt fram:
+ *
+ * `base-default` som fyll. Det er det kulørte trinnet - blå, turkis, ambra,
+ * rød, grønn - og kulør er det øyet sorterer nodene etter.
+ *
+ * `border-strong` som omriss. Fyllet alene holder ikke: i mørkt tema har
+ * `lib` sitt fyll bare 2,1:1 kontrast mot bakgrunnen og `app` 2,38:1, under
+ * WCAG 1.4.11 sitt krav på 3:1 for grafikk som bærer informasjon. Omrisset
+ * ligger på 4,56:1 eller mer i begge tema og bærer kontrasten. Det er også
+ * omrisset som gjør de åpne servernodene synlige, siden de ikke har fyll.
+ *
+ * Familievalget er heller ikke tilfeldig. `brand2` (hue 25) ligger for nær
+ * `danger` (hue 0) til å skilles; `warning` (hue 37) gir `app` en kulør som
+ * står 37° fra nærmeste nabo. Et forsøk på å optimere alle fem fritt over
+ * tokensettet endte med to blåtoner og en nesten-svart, så begrensningen til
+ * én familie per lag er med vilje.
+ *
+ * `colors.test.ts` leser de bygde tokenene og feiler hvis et temabytte bryter
+ * kontrastgrensen eller lar to lag få nesten samme kulør.
+ *
+ * Farge er aldri eneste bærer av informasjon: filnavnet starter med laget, og
+ * tegnforklaringen står over grafen.
+ */
+export const LAYER_COLOR_FAMILIES: Record<Layer, string> = {
+  app: "warning",
+  components: "accent",
+  lib: "brand1",
+  providers: "danger",
+  services: "success",
+};
+
+const byLayer = (step: string) =>
+  Object.fromEntries(
+    Object.entries(LAYER_COLOR_FAMILIES).map(([layer, family]) => [
+      layer,
+      `var(--ds-color-${family}-${step})`,
+    ]),
+  ) as Record<Layer, string>;
+
+/** Kuløren. Fyller klientnodene, og er prikken i tegnforklaringen. */
+export const LAYER_FILL = byLayer("base-default");
+
+/** Kontrasten. Omriss på alle noder, og eneste farge på de åpne servernodene. */
+export const LAYER_STROKE = byLayer("border-strong");
+
+/**
+ * Kantene er nøytrale med vilje. Ga vi hver strek fargen til laget sitt, ville
+ * 132 streker konkurrert med de 85 nodene om den samme fargekoden.
+ */
+export const EDGE_COLOR = "var(--ds-color-neutral-border-strong)";
+export const EDGE_ACTIVE_COLOR = "var(--ds-color-neutral-text-default)";
+export const LABEL_COLOR = "var(--ds-color-neutral-text-default)";

--- a/components/architecture/graph/data.ts
+++ b/components/architecture/graph/data.ts
@@ -1,0 +1,25 @@
+import graphData from "@/data/architecture-graph.json";
+import { buildArchitectureGraph, type ModuleRecord } from "@/lib/architecture";
+
+/**
+ * Grafen, ferdig utledet, delt av figuren og tegnforklaringen.
+ *
+ * Den leses inn her og sendes ikke som props fra siden. AGENTS.md advarer mot å
+ * sende store statiske datastrukturer gjennom Client Component-props: da havner
+ * hele grafen i HTML-en som serialisert payload i tillegg til i bunten.
+ *
+ * Konsekvensen er verdt å nevne: dette er grunnen til at `lib/architecture.ts`
+ * og `lib/architecture-layout.ts` selv står som klientfiler i grafen. Grafen
+ * viser altså sin egen visualisering.
+ *
+ * Klient/server-skillet utledes av `buildArchitectureGraph` og ligger ikke i
+ * JSON-en, slik at utledningen bor på ett testet sted.
+ */
+export const ARCHITECTURE_MODULES = buildArchitectureGraph(
+  graphData.modules as ModuleRecord[],
+).modules;
+
+/** Oppslag framfor indeks: simuleringsnodene ligger ikke i samme rekkefølge. */
+export const RUNTIME_OF = new Map(
+  ARCHITECTURE_MODULES.map((record) => [record.id, record.runtime]),
+);

--- a/components/architecture/graph/labels.test.ts
+++ b/components/architecture/graph/labels.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { estimateWidth, hiddenLabels, type LabelBox } from "./labels";
+
+const box = (id: string, x: number, bottom: number, priority = 0): LabelBox => ({
+  id,
+  x,
+  bottom,
+  fontSize: 11,
+  characters: id.length,
+  priority,
+});
+
+describe("hiddenLabels", () => {
+  it("skjuler ingenting når navnene ligger fra hverandre", () => {
+    expect(hiddenLabels([box("lib/a.ts", 0, 0), box("lib/b.ts", 500, 400)]).size).toBe(0);
+  });
+
+  it("skjuler det ene når to navn ligger på samme punkt", () => {
+    const hidden = hiddenLabels([box("lib/a.ts", 100, 100), box("lib/b.ts", 100, 100)]);
+    expect(hidden.size).toBe(1);
+  });
+
+  it("lar filen med flest importører beholde navnet", () => {
+    const hidden = hiddenLabels([
+      box("lib/lite-brukt.ts", 100, 100, 1),
+      box("lib/mye-brukt.ts", 100, 100, 9),
+    ]);
+
+    expect([...hidden]).toEqual(["lib/lite-brukt.ts"]);
+  });
+
+  it("skjuler regresjonen den ble skrevet for", () => {
+    // De to ekte navnene som skrev over hverandre: nesten samme punkt, og
+    // begge over navneterskelen.
+    const hidden = hiddenLabels([
+      box("lib/architecture.ts", 380, 415, 6),
+      box("lib/architecture-layout.ts", 392, 419, 5),
+    ]);
+
+    expect([...hidden]).toEqual(["lib/architecture-layout.ts"]);
+  });
+
+  it("regner lange navn som breiere enn korte", () => {
+    // `lib/a.ts` er kort nok til å gå klar, mens et langt navn på samme sted
+    // strekker seg inn i naboen.
+    const kort = hiddenLabels([box("a.ts", 100, 100), box("b.ts", 140, 100)]);
+    const langt = hiddenLabels([
+      box("components/master/edge/NetworkControls.tsx", 100, 100),
+      box("components/master/edge/types.ts", 140, 100),
+    ]);
+
+    expect(kort.size).toBe(0);
+    expect(langt.size).toBe(1);
+  });
+
+  it("skiller navn som ligger over hverandre men på ulik høyde", () => {
+    expect(hiddenLabels([box("lib/a.ts", 100, 100), box("lib/b.ts", 100, 140)]).size).toBe(0);
+  });
+
+  it("velger det samme hver gang, også ved lik prioritet", () => {
+    const boxes = [box("lib/b.ts", 100, 100, 3), box("lib/a.ts", 100, 100, 3)];
+
+    expect([...hiddenLabels(boxes)]).toEqual([...hiddenLabels([...boxes].reverse())]);
+  });
+
+  it("tåler en tom liste", () => {
+    expect(hiddenLabels([]).size).toBe(0);
+  });
+});
+
+describe("estimateWidth", () => {
+  it("skalerer med både tegnantall og fontstørrelse", () => {
+    const small = { ...box("lib/utils.ts", 0, 0), fontSize: 11 };
+    const large = { ...small, fontSize: 13 };
+
+    expect(estimateWidth(large)).toBeGreaterThan(estimateWidth(small));
+    expect(estimateWidth(small)).toBeCloseTo("lib/utils.ts".length * 11 * 0.6, 5);
+  });
+});

--- a/components/architecture/graph/labels.ts
+++ b/components/architecture/graph/labels.ts
@@ -1,0 +1,72 @@
+/**
+ * Hvilke filnavn det er plass til.
+ *
+ * Uten dette la `lib/architecture.ts` og `lib/architecture-layout.ts` seg rett
+ * oppå hverandre til uleselig grøt: de ligger tett, og begge har nok importører
+ * til å vise navn.
+ *
+ * Ligger her som en ren funksjon fordi den ellers bare ville blitt kjørt av
+ * layouten i nettleseren, og da er kollisjonene vanskelige å framprovosere. Her
+ * kan de skrives som tall.
+ */
+export type LabelBox = {
+  id: string;
+  /** Midtpunktet vannrett. Navnene er sentrert over noden. */
+  x: number;
+  /** Grunnlinjen. Navnet strekker seg `fontSize` oppover derfra. */
+  bottom: number;
+  fontSize: number;
+  /** Antall tegn. Bredden anslås av dette, se `estimateWidth`. */
+  characters: number;
+  /** Høyere vinner plassen ved kollisjon. Antall importører i praksis. */
+  priority: number;
+};
+
+/**
+ * Bredden på et navn, anslått fra tegnantall.
+ *
+ * `getComputedTextLength` ville vært eksakt, men tvinger fram en
+ * layout-beregning per navn per animasjonsramme. Navnene er monospace, så
+ * tegnbredden er en fast andel av fontstørrelsen, og et anslag er nøyaktig nok
+ * til å avgjøre om to bokser krysser.
+ */
+export function estimateWidth(box: LabelBox): number {
+  return box.characters * box.fontSize * 0.6;
+}
+
+function overlaps(first: LabelBox, second: LabelBox): boolean {
+  const firstWidth = estimateWidth(first) / 2;
+  const secondWidth = estimateWidth(second) / 2;
+  return (
+    first.x - firstWidth < second.x + secondWidth &&
+    first.x + firstWidth > second.x - secondWidth &&
+    first.bottom - first.fontSize < second.bottom &&
+    first.bottom > second.bottom - second.fontSize
+  );
+}
+
+/**
+ * Navnene som må vike, gitt at de viktigste får plassen først.
+ *
+ * Grådig og ikke optimal: å finne det største settet uten kollisjoner er dyrt,
+ * og en graf som faller til ro flytter boksene hver ramme uansett. Det som
+ * betyr noe er at valget er stabilt og at de mest importerte filene vinner.
+ */
+export function hiddenLabels(boxes: readonly LabelBox[]): Set<string> {
+  const hidden = new Set<string>();
+  const placed: LabelBox[] = [];
+
+  // Lik prioritet avgjøres av id, ellers ville to like viktige filer kunnet
+  // bytte på å vike mellom rammene og blinke.
+  const order = [...boxes].sort(
+    (first, second) =>
+      second.priority - first.priority || first.id.localeCompare(second.id),
+  );
+
+  for (const box of order) {
+    if (placed.some((other) => overlaps(box, other))) hidden.add(box.id);
+    else placed.push(box);
+  }
+
+  return hidden;
+}

--- a/components/architecture/graph/settings.ts
+++ b/components/architecture/graph/settings.ts
@@ -1,0 +1,60 @@
+import type { LayoutSettings } from "@/lib/architecture-layout";
+
+/**
+ * Innstillinger for arkitekturgrafen.
+ *
+ * `width` og `height` er en logisk `viewBox`, ikke piksler på skjermen. SVG-en
+ * skaleres med CSS, så layouten regnes ut én gang og trenger ingen ny runde ved
+ * resize - og den blir den samme uansett skjermstørrelse.
+ *
+ * Tallene er ikke gjettet, de er målt mot den ekte grafen. Første forsøk ga
+ * nærmeste nodepar på 0,0 px og 45 par tettere enn 14 px. Disse verdiene gir
+ * 36 px minsteavstand, ingen tette par, og de tilknyttede nodene dekker 76 % av
+ * bredden og 80 % av høyden.
+ */
+export type GraphSettings = LayoutSettings & {
+  width: number;
+  height: number;
+  /** Simuleringssteg per animasjonsramme. Høyere = raskere til ro. */
+  stepsPerFrame: number;
+  /** Filer med minst så mange importører får navnet sitt vist uten hover. */
+  labelThreshold: number;
+};
+
+export const BASE_SETTINGS: GraphSettings = {
+  width: 1100,
+  height: 700,
+  iterations: 300,
+  idealDistanceScale: 1,
+  repulsion: 1,
+  attraction: 0.35,
+  centeringPull: 0.02,
+  isolatedPull: 4,
+  temperature: 0.06,
+  margin: 40,
+  stepsPerFrame: 2,
+  labelThreshold: 5,
+};
+
+/**
+ * Mobil får samme layout, men færre steg per ramme og strengere terskel for
+ * navn: 79 filnavn på en telefonskjerm er ikke lesbart uansett hvor pent det er
+ * plassert.
+ */
+export const MOBILE_SETTINGS: GraphSettings = {
+  ...BASE_SETTINGS,
+  stepsPerFrame: 3,
+  labelThreshold: 6,
+};
+
+/**
+ * `prefers-reduced-motion`: ingen animasjon i det hele tatt.
+ *
+ * Grafen regnes ferdig før første maling og står stille. Å bare senke farten
+ * ville fortsatt vært vedvarende bevegelse, og det er nettopp det brukeren har
+ * bedt om å slippe.
+ */
+export const REDUCED_SETTINGS: GraphSettings = {
+  ...BASE_SETTINGS,
+  stepsPerFrame: 0,
+};

--- a/components/architecture/graph/settings.ts
+++ b/components/architecture/graph/settings.ts
@@ -9,8 +9,11 @@ import type { LayoutSettings } from "@/lib/architecture-layout";
  *
  * Tallene er ikke gjettet, de er målt mot den ekte grafen. Første forsøk ga
  * nærmeste nodepar på 0,0 px og 45 par tettere enn 14 px. Disse verdiene gir
- * 36 px minsteavstand, ingen tette par, og de tilknyttede nodene dekker 76 % av
- * bredden og 80 % av høyden.
+ * 34 px minsteavstand og ingen tette par når simuleringen har falt til ro.
+ *
+ * Merk at mellomtilstandene er tettere enn sluttresultatet: ved steg 0 er
+ * nærmeste par 0,7 px. Et skjermbilde av en graf som fortsatt animerer sier
+ * altså ingenting om layouten.
  */
 export type GraphSettings = LayoutSettings & {
   width: number;
@@ -33,18 +36,24 @@ export const BASE_SETTINGS: GraphSettings = {
   temperature: 0.06,
   margin: 40,
   stepsPerFrame: 2,
-  labelThreshold: 5,
+  labelThreshold: 4,
 };
 
 /**
- * Mobil får samme layout, men færre steg per ramme og strengere terskel for
- * navn: 79 filnavn på en telefonskjerm er ikke lesbart uansett hvor pent det er
- * plassert.
+ * Mobil får samme layout, men flere steg per ramme og strengere terskel for
+ * navn.
+ *
+ * Flere steg betyr at grafen faller til ro på færre rammer. Bevegelsen er det
+ * som koster mest på en telefon, og selve steget er billig: 93 noder er rundt
+ * 4300 par, så tre steg per ramme er fortsatt småpenger.
+ *
+ * Terskelen strammes fordi 93 filnavn på en telefonskjerm ikke er lesbart
+ * uansett hvor pent det er plassert.
  */
 export const MOBILE_SETTINGS: GraphSettings = {
   ...BASE_SETTINGS,
   stepsPerFrame: 3,
-  labelThreshold: 6,
+  labelThreshold: 5,
 };
 
 /**

--- a/components/architecture/graph/summary.ts
+++ b/components/architecture/graph/summary.ts
@@ -1,0 +1,37 @@
+import { LAYERS, type ArchitectureModule } from "@/lib/architecture";
+
+/**
+ * Teksten en skjermleser får av grafen.
+ *
+ * SVG-en er `role="img"`, så dette er hele innholdet - figuren har ingen
+ * tilgjengelig struktur utover dette. Beskrivelsen må derfor bære formen på
+ * grafen: hvor mange filer per lag, hvor mange som havner i nettleseren, og hva
+ * en pil betyr.
+ *
+ * Den ligger i sin egen fil fordi den er en ren funksjon av grafen og dermed
+ * kan testes uten å rendre noe.
+ */
+export function describeGraph(
+  modules: readonly ArchitectureModule[],
+  edgeCount: number,
+): string {
+  const clients = modules.filter((record) => record.runtime === "client").length;
+  const perLayer = LAYERS.map(
+    (layer) => `${layer} ${modules.filter((record) => record.layer === layer).length}`,
+  ).join(", ");
+
+  return (
+    `Importgraf over kildekoden: ${modules.length} filer og ${edgeCount} ` +
+    `avhengigheter, der en pil betyr at filen importerer den den peker på. ` +
+    `${clients} filer havner i nettleserbunten, ${modules.length - clients} ` +
+    `kjører bare på serveren. Filer per lag: ${perLayer}.`
+  );
+}
+
+/** Radiusen til en node, gitt hvor mange filer som importerer den. */
+export function nodeRadius(inDegree: number): number {
+  // Minsteradius 4, ikke 3: en node på 6 px i diameter er vanskelig å treffe.
+  // Kvadratrot og ikke lineært, så `lib/utils.ts` med 8 importører ikke blir en
+  // flate som dekker naboene sine.
+  return 4 + Math.sqrt(inDegree) * 2.4;
+}

--- a/components/architecture/graph/useActiveNode.ts
+++ b/components/architecture/graph/useActiveNode.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { LayoutEdge } from "@/lib/architecture-layout";
+
+/**
+ * Hvilken fil som er markert, og hva den henger sammen med.
+ *
+ * Naboene regnes i begge retninger: peker man på en fil vil man se både hva den
+ * importerer og hvem som importerer den, ikke bare den ene halvparten.
+ */
+export function useActiveNode(edges: readonly LayoutEdge[]) {
+  const [active, setActive] = useState<string | null>(null);
+
+  const neighbours = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    const link = (from: string, to: string) => {
+      if (!map.has(from)) map.set(from, new Set());
+      map.get(from)?.add(to);
+    };
+    for (const edge of edges) {
+      link(edge.from, edge.to);
+      link(edge.to, edge.from);
+    }
+    return map;
+  }, [edges]);
+
+  /** null betyr at ingenting er markert, altså at alt skal vises likt. */
+  const activeSet = useMemo(
+    () => (active ? new Set([active, ...(neighbours.get(active) ?? [])]) : null),
+    [active, neighbours],
+  );
+
+  return { active, activeSet, setActive };
+}

--- a/components/architecture/graph/useGraphLayout.ts
+++ b/components/architecture/graph/useGraphLayout.ts
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { ArchitectureModule } from "@/lib/architecture";
+import {
+  createFrameTransform,
+  createSimulation,
+  settleSimulation,
+  stepSimulation,
+  transformX,
+  transformY,
+} from "@/lib/architecture-layout";
+
+import { hiddenLabels, type LabelBox } from "./labels";
+import type { GraphSettings } from "./settings";
+import { nodeRadius } from "./summary";
+
+/** Luft mellom pilspissen og målnoden, så spissen er tydelig løsrevet. */
+const ARROW_GAP = 3;
+
+export type GraphElements = {
+  nodes: React.RefObject<(SVGCircleElement | null)[]>;
+  labels: React.RefObject<(SVGTextElement | null)[]>;
+  edges: React.RefObject<(SVGLineElement | null)[]>;
+};
+
+/**
+ * Kjører layouten og skriver posisjonene rett på DOM-nodene.
+ *
+ * Posisjonene settes imperativt og ikke gjennom React-state. 85 noder, 85
+ * navn og 132 kanter er over 300 elementer som flytter seg hver ramme, og en
+ * ny render per ramme av det ville vært bortkastet arbeid - ingenting annet enn
+ * koordinatene endrer seg.
+ *
+ * Koordinatene settes dessuten bare på klienten, aldri i HTML-en. Layouten er
+ * deterministisk innenfor én JavaScript-motor, men `Math.cos` og `Math.sin` er
+ * ikke pålagt å gi bit-identiske svar på tvers av dem. Nodes V8 og Chromes V8
+ * ga 779.2369769141981 mot 779.236976914198, og React meldte hydration mismatch
+ * på hver linje og sirkel. Med 300 iterasjoner kan et avvik på siste bit vokse,
+ * så avrunding ville bare skjult det.
+ *
+ * `painted` er derfor false til første posisjonsskriving, og grafen fades inn.
+ * Tegnforklaringen er en serverkomponent og påvirkes ikke, så siden er ikke tom
+ * imens.
+ */
+export function useGraphLayout(
+  modules: readonly ArchitectureModule[],
+  settings: GraphSettings,
+) {
+  const [painted, setPainted] = useState(false);
+
+  const simulation = useMemo(() => {
+    const created = createSimulation(modules, settings.width, settings.height, settings);
+    // Uten animasjon skal grafen stå ferdig ved første maling, ikke falle til ro
+    // etterpå.
+    return settings.stepsPerFrame === 0 ? settleSimulation(created, settings) : created;
+  }, [modules, settings]);
+
+  /** Kantene som node-indekser, så animasjonen slipper oppslag per ramme. */
+  const edgeIndices = useMemo(() => {
+    const indexOf = new Map(simulation.nodes.map((node, index) => [node.id, index]));
+    return simulation.edges.map((edge) => ({
+      from: indexOf.get(edge.from) ?? 0,
+      to: indexOf.get(edge.to) ?? 0,
+    }));
+  }, [simulation]);
+
+  const elements: GraphElements = {
+    nodes: useRef<(SVGCircleElement | null)[]>([]),
+    labels: useRef<(SVGTextElement | null)[]>([]),
+    edges: useRef<(SVGLineElement | null)[]>([]),
+  };
+
+  useEffect(() => {
+    const writePositions = () => {
+      // Regnes ut på nytt hver ramme, så grafen fyller rammen hele veien mens den
+      // faller til ro - ikke bare når den er ferdig.
+      const frame = createFrameTransform(simulation, settings);
+      const screenX = (value: number) => transformX(frame, value);
+      const screenY = (value: number) => transformY(frame, value);
+
+      simulation.nodes.forEach((node, index) => {
+        const x = screenX(node.x);
+        const y = screenY(node.y);
+        elements.nodes.current[index]?.setAttribute("cx", String(x));
+        elements.nodes.current[index]?.setAttribute("cy", String(y));
+        elements.labels.current[index]?.setAttribute("x", String(x));
+        elements.labels.current[index]?.setAttribute(
+          "y",
+          String(y - nodeRadius(node.inDegree) - 4),
+        );
+      });
+
+      edgeIndices.forEach((edge, index) => {
+        const from = simulation.nodes[edge.from];
+        const to = simulation.nodes[edge.to];
+        const element = elements.edges.current[index];
+        if (!from || !to || !element) return;
+
+        const x1 = screenX(from.x);
+        const y1 = screenY(from.y);
+        const x2 = screenX(to.x);
+        const y2 = screenY(to.y);
+
+        // Streken stopper på kanten av målnoden, ikke i sentrum: ellers ville
+        // pilspissen ligget under sirkelen og retningen vært usynlig.
+        const deltaX = x2 - x1;
+        const deltaY = y2 - y1;
+        const length = Math.max(0.01, Math.hypot(deltaX, deltaY));
+        const inset = Math.min(length - 0.01, nodeRadius(to.inDegree) + ARROW_GAP);
+
+        element.setAttribute("x1", String(x1));
+        element.setAttribute("y1", String(y1));
+        element.setAttribute("x2", String(x2 - (deltaX / length) * inset));
+        element.setAttribute("y2", String(y2 - (deltaY / length) * inset));
+      });
+
+      hideCollidingLabels();
+    };
+
+    /**
+     * Skjuler filnavn som ville lagt seg oppå et annet.
+     *
+     * Arbeidsdelingen: React bestemmer hvilke navn som er aktuelle, gjennom
+     * `fill-opacity`. `hiddenLabels` bestemmer hvilke av dem det er plass til,
+     * og svaret settes med `style.opacity`. To ulike egenskaper, så ingen av dem
+     * overskriver den andre.
+     */
+    function hideCollidingLabels() {
+      const eligible: LabelBox[] = [];
+      const elementOf = new Map<string, SVGTextElement>();
+
+      simulation.nodes.forEach((node, index) => {
+        const element = elements.labels.current[index];
+        if (!element) return;
+        if (element.getAttribute("fill-opacity") === "0") {
+          element.style.opacity = "";
+          return;
+        }
+
+        elementOf.set(node.id, element);
+        eligible.push({
+          id: node.id,
+          x: Number(element.getAttribute("x")),
+          bottom: Number(element.getAttribute("y")),
+          fontSize: Number(element.getAttribute("font-size")) || 11,
+          characters: node.id.length,
+          priority: node.inDegree,
+        });
+      });
+
+      const hidden = hiddenLabels(eligible);
+      for (const [id, element] of elementOf) {
+        element.style.opacity = hidden.has(id) ? "0" : "1";
+      }
+    }
+
+    writePositions();
+    setPainted(true);
+    if (settings.stepsPerFrame === 0) return;
+
+    let frame = requestAnimationFrame(function tick() {
+      for (let step = 0; step < settings.stepsPerFrame; step += 1) {
+        stepSimulation(simulation, settings);
+      }
+      writePositions();
+      // Stopper når grafen har falt til ro. Ingen evig animasjon å måtte skru av.
+      if (simulation.step < settings.iterations) frame = requestAnimationFrame(tick);
+    });
+
+    return () => cancelAnimationFrame(frame);
+    // `elements.*` er ref-objekter fra `useRef` og dermed stabile, men de står i
+    // lista for at regelen skal kunne verifisere det selv.
+  }, [edgeIndices, elements.edges, elements.labels, elements.nodes, settings, simulation]);
+
+  return { simulation, elements, painted };
+}

--- a/components/architecture/graph/useGraphLayout.ts
+++ b/components/architecture/graph/useGraphLayout.ts
@@ -28,8 +28,8 @@ export type GraphElements = {
 /**
  * Kjører layouten og skriver posisjonene rett på DOM-nodene.
  *
- * Posisjonene settes imperativt og ikke gjennom React-state. 85 noder, 85
- * navn og 132 kanter er over 300 elementer som flytter seg hver ramme, og en
+ * Posisjonene settes imperativt og ikke gjennom React-state. 93 noder, 93
+ * navn og 127 kanter er over 300 elementer som flytter seg hver ramme, og en
  * ny render per ramme av det ville vært bortkastet arbeid - ingenting annet enn
  * koordinatene endrer seg.
  *

--- a/data/architecture-graph.json
+++ b/data/architecture-graph.json
@@ -4,7 +4,8 @@
       "id": "app/architecture/page.tsx",
       "directive": null,
       "imports": [
-        "components/architecture/ArchitectureGraph.tsx"
+        "components/architecture/ArchitectureGraph.tsx",
+        "components/architecture/GraphLegend.tsx"
       ],
       "external": [
         "next"
@@ -176,9 +177,106 @@
       "id": "components/architecture/ArchitectureGraph.tsx",
       "directive": "use client",
       "imports": [
+        "components/architecture/graph/GraphEdges.tsx",
+        "components/architecture/graph/GraphLabels.tsx",
+        "components/architecture/graph/GraphNodes.tsx",
+        "components/architecture/graph/data.ts",
         "components/architecture/graph/settings.ts",
-        "components/visualization/useVisualizationEnvironment.ts",
+        "components/architecture/graph/summary.ts",
+        "components/architecture/graph/useActiveNode.ts",
+        "components/architecture/graph/useGraphLayout.ts",
+        "components/visualization/useVisualizationEnvironment.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/colors.ts",
+      "directive": null,
+      "imports": [
+        "lib/architecture.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/data.ts",
+      "directive": null,
+      "imports": [
         "data/architecture-graph.json",
+        "lib/architecture.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/GraphEdges.tsx",
+      "directive": null,
+      "imports": [
+        "components/architecture/graph/colors.ts",
+        "components/architecture/graph/useGraphLayout.ts",
+        "lib/architecture-layout.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/GraphLabels.tsx",
+      "directive": null,
+      "imports": [
+        "components/architecture/graph/colors.ts",
+        "components/architecture/graph/useGraphLayout.ts",
+        "lib/architecture-layout.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/GraphNodes.tsx",
+      "directive": null,
+      "imports": [
+        "components/architecture/graph/colors.ts",
+        "components/architecture/graph/summary.ts",
+        "components/architecture/graph/useGraphLayout.ts",
+        "lib/architecture-layout.ts",
+        "lib/architecture.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/labels.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/settings.ts",
+      "directive": null,
+      "imports": [
+        "lib/architecture-layout.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/summary.ts",
+      "directive": null,
+      "imports": [
+        "lib/architecture.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/architecture/graph/useActiveNode.ts",
+      "directive": "use client",
+      "imports": [
+        "lib/architecture-layout.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/architecture/graph/useGraphLayout.ts",
+      "directive": "use client",
+      "imports": [
+        "components/architecture/graph/labels.ts",
+        "components/architecture/graph/settings.ts",
+        "components/architecture/graph/summary.ts",
         "lib/architecture-layout.ts",
         "lib/architecture.ts"
       ],
@@ -187,10 +285,12 @@
       ]
     },
     {
-      "id": "components/architecture/graph/settings.ts",
+      "id": "components/architecture/GraphLegend.tsx",
       "directive": null,
       "imports": [
-        "lib/architecture-layout.ts"
+        "components/architecture/graph/colors.ts",
+        "components/architecture/graph/data.ts",
+        "lib/architecture.ts"
       ],
       "external": []
     },

--- a/data/architecture-graph.json
+++ b/data/architecture-graph.json
@@ -7,16 +7,13 @@
         "components/architecture/ArchitectureGraph.tsx",
         "components/architecture/GraphLegend.tsx"
       ],
-      "external": [
-        "next"
-      ]
+      "external": []
     },
     {
       "id": "app/cv/cv.data.ts",
       "directive": null,
       "imports": [],
       "external": [
-        "react-icons",
         "react-icons/fa",
         "react-icons/si"
       ]
@@ -30,7 +27,6 @@
       ],
       "external": [
         "@digdir/designsystemet-react",
-        "next",
         "next-view-transitions",
         "next/image",
         "react-icons/fa",
@@ -50,7 +46,6 @@
       "id": "app/layout.tsx",
       "directive": null,
       "imports": [
-        "app/globals.css",
         "components/layout/Footer.tsx",
         "components/layout/Navbar.tsx",
         "components/layout/VisitTracker.tsx",
@@ -58,7 +53,6 @@
       ],
       "external": [
         "@vercel/analytics/next",
-        "next",
         "next-view-transitions",
         "next/font/google",
         "next/script"
@@ -73,8 +67,7 @@
         "lib/master.ts"
       ],
       "external": [
-        "@digdir/designsystemet-react",
-        "next"
+        "@digdir/designsystemet-react"
       ]
     },
     {
@@ -83,9 +76,7 @@
       "imports": [
         "components/home/MstVisualization.tsx"
       ],
-      "external": [
-        "next"
-      ]
+      "external": []
     },
     {
       "id": "app/not-found.tsx",
@@ -126,7 +117,6 @@
       ],
       "external": [
         "@digdir/designsystemet-react",
-        "next",
         "next/image"
       ]
     },
@@ -135,7 +125,6 @@
       "directive": null,
       "imports": [],
       "external": [
-        "react-icons",
         "react-icons/si"
       ]
     },
@@ -143,9 +132,7 @@
       "id": "app/robots.ts",
       "directive": null,
       "imports": [],
-      "external": [
-        "next"
-      ]
+      "external": []
     },
     {
       "id": "app/running/page.tsx",
@@ -159,7 +146,6 @@
       "external": [
         "@digdir/designsystemet-react",
         "@tanstack/react-query",
-        "next",
         "next/navigation"
       ]
     },
@@ -169,9 +155,7 @@
       "imports": [
         "lib/features.ts"
       ],
-      "external": [
-        "next"
-      ]
+      "external": []
     },
     {
       "id": "components/architecture/ArchitectureGraph.tsx",
@@ -192,16 +176,13 @@
     {
       "id": "components/architecture/graph/colors.ts",
       "directive": null,
-      "imports": [
-        "lib/architecture.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {
       "id": "components/architecture/graph/data.ts",
       "directive": null,
       "imports": [
-        "data/architecture-graph.json",
         "lib/architecture.ts"
       ],
       "external": []
@@ -210,9 +191,7 @@
       "id": "components/architecture/graph/GraphEdges.tsx",
       "directive": null,
       "imports": [
-        "components/architecture/graph/colors.ts",
-        "components/architecture/graph/useGraphLayout.ts",
-        "lib/architecture-layout.ts"
+        "components/architecture/graph/colors.ts"
       ],
       "external": []
     },
@@ -220,9 +199,7 @@
       "id": "components/architecture/graph/GraphLabels.tsx",
       "directive": null,
       "imports": [
-        "components/architecture/graph/colors.ts",
-        "components/architecture/graph/useGraphLayout.ts",
-        "lib/architecture-layout.ts"
+        "components/architecture/graph/colors.ts"
       ],
       "external": []
     },
@@ -231,10 +208,7 @@
       "directive": null,
       "imports": [
         "components/architecture/graph/colors.ts",
-        "components/architecture/graph/summary.ts",
-        "components/architecture/graph/useGraphLayout.ts",
-        "lib/architecture-layout.ts",
-        "lib/architecture.ts"
+        "components/architecture/graph/summary.ts"
       ],
       "external": []
     },
@@ -247,9 +221,7 @@
     {
       "id": "components/architecture/graph/settings.ts",
       "directive": null,
-      "imports": [
-        "lib/architecture-layout.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {
@@ -263,9 +235,7 @@
     {
       "id": "components/architecture/graph/useActiveNode.ts",
       "directive": "use client",
-      "imports": [
-        "lib/architecture-layout.ts"
-      ],
+      "imports": [],
       "external": [
         "react"
       ]
@@ -275,10 +245,8 @@
       "directive": "use client",
       "imports": [
         "components/architecture/graph/labels.ts",
-        "components/architecture/graph/settings.ts",
         "components/architecture/graph/summary.ts",
-        "lib/architecture-layout.ts",
-        "lib/architecture.ts"
+        "lib/architecture-layout.ts"
       ],
       "external": [
         "react"
@@ -305,19 +273,13 @@
     {
       "id": "components/home/astar/render.ts",
       "directive": null,
-      "imports": [
-        "components/home/astar/colors.ts",
-        "components/home/astar/scene.ts",
-        "components/home/astar/settings.ts",
-        "lib/astar.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {
       "id": "components/home/astar/scene.ts",
       "directive": null,
       "imports": [
-        "components/home/astar/settings.ts",
         "lib/astar.ts"
       ],
       "external": []
@@ -392,7 +354,6 @@
       "id": "components/home/mst/scene.ts",
       "directive": null,
       "imports": [
-        "components/home/mst/settings.ts",
         "lib/mst.ts"
       ],
       "external": []
@@ -552,9 +513,7 @@
     {
       "id": "components/master/edge/config.ts",
       "directive": null,
-      "imports": [
-        "components/master/edge/types.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {
@@ -562,7 +521,6 @@
       "directive": null,
       "imports": [
         "components/master/edge/config.ts",
-        "components/master/edge/types.ts",
         "components/ui/badge.tsx",
         "components/ui/slider.tsx",
         "components/ui/switch.tsx",
@@ -578,21 +536,18 @@
       "imports": [
         "components/master/edge/config.ts",
         "components/master/edge/particles.ts",
-        "components/master/edge/types.ts",
         "lib/utils.ts"
       ],
       "external": [
         "framer-motion",
-        "lucide-react",
-        "react"
+        "lucide-react"
       ]
     },
     {
       "id": "components/master/edge/particles.ts",
       "directive": null,
       "imports": [
-        "components/master/edge/config.ts",
-        "components/master/edge/types.ts"
+        "components/master/edge/config.ts"
       ],
       "external": []
     },
@@ -609,8 +564,7 @@
         "components/master/edge/NetworkControls.tsx",
         "components/master/edge/NetworkMap.tsx",
         "components/master/edge/config.ts",
-        "components/master/edge/particles.ts",
-        "components/master/edge/types.ts"
+        "components/master/edge/particles.ts"
       ],
       "external": [
         "react"
@@ -651,7 +605,6 @@
       "id": "components/projects/snake/game.ts",
       "directive": null,
       "imports": [
-        "components/projects/snake/settings.ts",
         "lib/astar.ts"
       ],
       "external": []
@@ -665,20 +618,14 @@
     {
       "id": "components/running/basemap.ts",
       "directive": null,
-      "imports": [
-        "lib/color-scheme.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {
       "id": "components/running/heatmap-layer.ts",
       "directive": null,
-      "imports": [
-        "lib/color-scheme.ts"
-      ],
-      "external": [
-        "maplibre-gl"
-      ]
+      "imports": [],
+      "external": []
     },
     {
       "id": "components/running/HeatmapMap.tsx",
@@ -687,8 +634,7 @@
         "components/running/basemap.ts",
         "components/running/heatmap-layer.ts",
         "lib/color-scheme.ts",
-        "lib/heatmap.ts",
-        "services/api/heatmap.ts"
+        "lib/heatmap.ts"
       ],
       "external": [
         "maplibre-gl",
@@ -700,8 +646,7 @@
       "id": "components/running/HeatmapTeaser.tsx",
       "directive": null,
       "imports": [
-        "lib/heatmap.ts",
-        "services/api/heatmap.ts"
+        "lib/heatmap.ts"
       ],
       "external": [
         "@digdir/designsystemet-react",
@@ -872,9 +817,7 @@
     {
       "id": "lib/heatmap.ts",
       "directive": null,
-      "imports": [
-        "services/api/heatmap.ts"
-      ],
+      "imports": [],
       "external": []
     },
     {

--- a/data/architecture-graph.json
+++ b/data/architecture-graph.json
@@ -1,6 +1,16 @@
 {
   "modules": [
     {
+      "id": "app/architecture/page.tsx",
+      "directive": null,
+      "imports": [
+        "components/architecture/ArchitectureGraph.tsx"
+      ],
+      "external": [
+        "next"
+      ]
+    },
+    {
       "id": "app/cv/cv.data.ts",
       "directive": null,
       "imports": [],
@@ -161,6 +171,28 @@
       "external": [
         "next"
       ]
+    },
+    {
+      "id": "components/architecture/ArchitectureGraph.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/architecture/graph/settings.ts",
+        "components/visualization/useVisualizationEnvironment.ts",
+        "data/architecture-graph.json",
+        "lib/architecture-layout.ts",
+        "lib/architecture.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/architecture/graph/settings.ts",
+      "directive": null,
+      "imports": [
+        "lib/architecture-layout.ts"
+      ],
+      "external": []
     },
     {
       "id": "components/home/astar/colors.ts",
@@ -696,6 +728,14 @@
       "external": [
         "react"
       ]
+    },
+    {
+      "id": "lib/architecture-layout.ts",
+      "directive": null,
+      "imports": [
+        "lib/architecture.ts"
+      ],
+      "external": []
     },
     {
       "id": "lib/architecture.ts",

--- a/data/architecture-graph.json
+++ b/data/architecture-graph.json
@@ -1,0 +1,818 @@
+{
+  "modules": [
+    {
+      "id": "app/cv/cv.data.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "react-icons",
+        "react-icons/fa",
+        "react-icons/si"
+      ]
+    },
+    {
+      "id": "app/cv/page.tsx",
+      "directive": null,
+      "imports": [
+        "app/cv/cv.data.ts",
+        "components/ui/accessible-dialog.tsx"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "next",
+        "next-view-transitions",
+        "next/image",
+        "react-icons/fa",
+        "react-icons/fi"
+      ]
+    },
+    {
+      "id": "app/error.tsx",
+      "directive": "use client",
+      "imports": [],
+      "external": [
+        "@digdir/designsystemet-react",
+        "react"
+      ]
+    },
+    {
+      "id": "app/layout.tsx",
+      "directive": null,
+      "imports": [
+        "app/globals.css",
+        "components/layout/Footer.tsx",
+        "components/layout/Navbar.tsx",
+        "components/layout/VisitTracker.tsx",
+        "providers/ReactQueryProvider.tsx"
+      ],
+      "external": [
+        "@vercel/analytics/next",
+        "next",
+        "next-view-transitions",
+        "next/font/google",
+        "next/script"
+      ]
+    },
+    {
+      "id": "app/master/page.tsx",
+      "directive": null,
+      "imports": [
+        "components/master/EdgeComputingVisualization.tsx",
+        "components/master/MasterProgress.tsx",
+        "lib/master.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "next"
+      ]
+    },
+    {
+      "id": "app/mst/page.tsx",
+      "directive": null,
+      "imports": [
+        "components/home/MstVisualization.tsx"
+      ],
+      "external": [
+        "next"
+      ]
+    },
+    {
+      "id": "app/not-found.tsx",
+      "directive": null,
+      "imports": [
+        "components/home/AStarVisualization.tsx"
+      ],
+      "external": [
+        "@digdir/designsystemet-react"
+      ]
+    },
+    {
+      "id": "app/opengraph-image.tsx",
+      "directive": null,
+      "imports": [
+        "lib/mst.ts"
+      ],
+      "external": [
+        "next/og"
+      ]
+    },
+    {
+      "id": "app/page.tsx",
+      "directive": null,
+      "imports": [
+        "components/home/BentoGrid.tsx",
+        "components/home/HomeVisualization.tsx"
+      ],
+      "external": []
+    },
+    {
+      "id": "app/projects/page.tsx",
+      "directive": null,
+      "imports": [
+        "app/projects/projects.data.ts",
+        "components/projects/AutoSnakeBackground.tsx",
+        "components/ui/accessible-dialog.tsx"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "next",
+        "next/image"
+      ]
+    },
+    {
+      "id": "app/projects/projects.data.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "react-icons",
+        "react-icons/si"
+      ]
+    },
+    {
+      "id": "app/robots.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "next"
+      ]
+    },
+    {
+      "id": "app/running/page.tsx",
+      "directive": null,
+      "imports": [
+        "components/running/RunningHeatmap.tsx",
+        "components/running/queries.ts",
+        "lib/features.ts",
+        "lib/query-client.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "@tanstack/react-query",
+        "next",
+        "next/navigation"
+      ]
+    },
+    {
+      "id": "app/sitemap.ts",
+      "directive": null,
+      "imports": [
+        "lib/features.ts"
+      ],
+      "external": [
+        "next"
+      ]
+    },
+    {
+      "id": "components/home/astar/colors.ts",
+      "directive": null,
+      "imports": [
+        "components/visualization/canvas.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/home/astar/render.ts",
+      "directive": null,
+      "imports": [
+        "components/home/astar/colors.ts",
+        "components/home/astar/scene.ts",
+        "components/home/astar/settings.ts",
+        "lib/astar.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/home/astar/scene.ts",
+      "directive": null,
+      "imports": [
+        "components/home/astar/settings.ts",
+        "lib/astar.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/home/astar/settings.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/home/AStarVisualization.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/home/astar/colors.ts",
+        "components/home/astar/render.ts",
+        "components/home/astar/scene.ts",
+        "components/home/astar/settings.ts",
+        "components/visualization/canvas.ts",
+        "components/visualization/useVisualizationEnvironment.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/home/BentoGrid.tsx",
+      "directive": null,
+      "imports": [
+        "components/home/MasterCountdown.tsx",
+        "components/home/PrefetchedStatsCards.tsx",
+        "components/home/StatsCards.tsx",
+        "components/running/PrefetchedHeatmapTeaser.tsx",
+        "lib/features.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "next-view-transitions",
+        "next/image",
+        "react",
+        "react-icons/ai",
+        "react-icons/fa",
+        "react-icons/fi"
+      ]
+    },
+    {
+      "id": "components/home/HomeVisualization.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/home/AStarVisualization.tsx",
+        "components/home/MstVisualization.tsx",
+        "lib/background-visualization.ts"
+      ],
+      "external": [
+        "next/dynamic",
+        "react"
+      ]
+    },
+    {
+      "id": "components/home/MasterCountdown.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/master.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "next-view-transitions",
+        "react"
+      ]
+    },
+    {
+      "id": "components/home/mst/scene.ts",
+      "directive": null,
+      "imports": [
+        "components/home/mst/settings.ts",
+        "lib/mst.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/home/mst/settings.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/home/MstVisualization.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/home/mst/scene.ts",
+        "components/home/mst/settings.ts",
+        "components/visualization/useVisualizationEnvironment.ts",
+        "lib/mst.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/home/PrefetchedStatsCards.tsx",
+      "directive": null,
+      "imports": [
+        "components/home/StatsCards.tsx",
+        "components/home/queries.ts",
+        "lib/query-client.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "components/home/queries.ts",
+      "directive": null,
+      "imports": [
+        "services/api/stats.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "components/home/StatsCards.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/home/queries.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "@tanstack/react-query",
+        "lucide-react"
+      ]
+    },
+    {
+      "id": "components/layout/ApiStatusLink.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/layout/queries.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "components/layout/BackgroundVisualizationToggle.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/background-visualization.ts"
+      ],
+      "external": [
+        "lucide-react",
+        "react"
+      ]
+    },
+    {
+      "id": "components/layout/CurrentYear.tsx",
+      "directive": "use client",
+      "imports": [],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/layout/Footer.tsx",
+      "directive": null,
+      "imports": [
+        "components/layout/CurrentYear.tsx"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "react-icons/ai",
+        "react-icons/fa"
+      ]
+    },
+    {
+      "id": "components/layout/Navbar.tsx",
+      "directive": null,
+      "imports": [
+        "components/layout/BackgroundVisualizationToggle.tsx",
+        "components/layout/PrefetchedApiStatusLink.tsx",
+        "components/layout/ThemeToggle.tsx"
+      ],
+      "external": [
+        "lucide-react",
+        "next-view-transitions",
+        "react"
+      ]
+    },
+    {
+      "id": "components/layout/PrefetchedApiStatusLink.tsx",
+      "directive": null,
+      "imports": [
+        "components/layout/ApiStatusLink.tsx",
+        "components/layout/queries.ts",
+        "lib/query-client.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "components/layout/queries.ts",
+      "directive": null,
+      "imports": [
+        "services/api/client.ts"
+      ],
+      "external": [
+        "@tanstack/react-query",
+        "zod"
+      ]
+    },
+    {
+      "id": "components/layout/ThemeToggle.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/color-scheme.ts"
+      ],
+      "external": [
+        "lucide-react"
+      ]
+    },
+    {
+      "id": "components/layout/VisitTracker.tsx",
+      "directive": "use client",
+      "imports": [
+        "services/api/analytics.ts"
+      ],
+      "external": [
+        "next/navigation",
+        "react"
+      ]
+    },
+    {
+      "id": "components/master/edge/config.ts",
+      "directive": null,
+      "imports": [
+        "components/master/edge/types.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/master/edge/NetworkControls.tsx",
+      "directive": null,
+      "imports": [
+        "components/master/edge/config.ts",
+        "components/master/edge/types.ts",
+        "components/ui/badge.tsx",
+        "components/ui/slider.tsx",
+        "components/ui/switch.tsx",
+        "components/ui/tabs.tsx"
+      ],
+      "external": [
+        "lucide-react"
+      ]
+    },
+    {
+      "id": "components/master/edge/NetworkMap.tsx",
+      "directive": null,
+      "imports": [
+        "components/master/edge/config.ts",
+        "components/master/edge/particles.ts",
+        "components/master/edge/types.ts",
+        "lib/utils.ts"
+      ],
+      "external": [
+        "framer-motion",
+        "lucide-react",
+        "react"
+      ]
+    },
+    {
+      "id": "components/master/edge/particles.ts",
+      "directive": null,
+      "imports": [
+        "components/master/edge/config.ts",
+        "components/master/edge/types.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/master/edge/types.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/master/EdgeComputingVisualization.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/master/edge/NetworkControls.tsx",
+        "components/master/edge/NetworkMap.tsx",
+        "components/master/edge/config.ts",
+        "components/master/edge/particles.ts",
+        "components/master/edge/types.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/master/MasterProgress.tsx",
+      "directive": "use client",
+      "imports": [],
+      "external": [
+        "@digdir/designsystemet-react",
+        "react"
+      ]
+    },
+    {
+      "id": "components/projects/AutoSnakeBackground.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/projects/snake/colors.ts",
+        "components/projects/snake/game.ts",
+        "components/projects/snake/settings.ts",
+        "components/visualization/canvas.ts",
+        "components/visualization/useVisualizationEnvironment.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/projects/snake/colors.ts",
+      "directive": null,
+      "imports": [
+        "components/visualization/canvas.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/projects/snake/game.ts",
+      "directive": null,
+      "imports": [
+        "components/projects/snake/settings.ts",
+        "lib/astar.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/projects/snake/settings.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/running/basemap.ts",
+      "directive": null,
+      "imports": [
+        "lib/color-scheme.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/running/heatmap-layer.ts",
+      "directive": null,
+      "imports": [
+        "lib/color-scheme.ts"
+      ],
+      "external": [
+        "maplibre-gl"
+      ]
+    },
+    {
+      "id": "components/running/HeatmapMap.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/running/basemap.ts",
+        "components/running/heatmap-layer.ts",
+        "lib/color-scheme.ts",
+        "lib/heatmap.ts",
+        "services/api/heatmap.ts"
+      ],
+      "external": [
+        "maplibre-gl",
+        "maplibre-gl/dist/maplibre-gl.css",
+        "react"
+      ]
+    },
+    {
+      "id": "components/running/HeatmapTeaser.tsx",
+      "directive": null,
+      "imports": [
+        "lib/heatmap.ts",
+        "services/api/heatmap.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "lucide-react",
+        "next-view-transitions"
+      ]
+    },
+    {
+      "id": "components/running/PrefetchedHeatmapTeaser.tsx",
+      "directive": null,
+      "imports": [
+        "components/running/HeatmapTeaser.tsx",
+        "components/running/queries.ts",
+        "lib/query-client.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "components/running/queries.ts",
+      "directive": null,
+      "imports": [
+        "services/api/heatmap.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "components/running/RunningHeatmap.tsx",
+      "directive": "use client",
+      "imports": [
+        "components/running/HeatmapMap.tsx",
+        "components/running/queries.ts"
+      ],
+      "external": [
+        "@digdir/designsystemet-react",
+        "@tanstack/react-query",
+        "next/dynamic"
+      ]
+    },
+    {
+      "id": "components/ui/accessible-dialog.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "framer-motion",
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/badge.tsx",
+      "directive": null,
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "class-variance-authority",
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/button.tsx",
+      "directive": null,
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "class-variance-authority",
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/card.tsx",
+      "directive": null,
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/slider.tsx",
+      "directive": null,
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/switch.tsx",
+      "directive": null,
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/ui/tabs.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/utils.ts"
+      ],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "components/visualization/canvas.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "components/visualization/useVisualizationEnvironment.ts",
+      "directive": "use client",
+      "imports": [],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "lib/architecture.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/astar.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/background-visualization.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/color-scheme.ts",
+      "directive": "use client",
+      "imports": [],
+      "external": [
+        "react"
+      ]
+    },
+    {
+      "id": "lib/features.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/heatmap.ts",
+      "directive": null,
+      "imports": [
+        "services/api/heatmap.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "lib/master.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/mst.ts",
+      "directive": null,
+      "imports": [],
+      "external": []
+    },
+    {
+      "id": "lib/query-client.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "@tanstack/react-query"
+      ]
+    },
+    {
+      "id": "lib/utils.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "clsx",
+        "tailwind-merge"
+      ]
+    },
+    {
+      "id": "providers/ReactQueryProvider.tsx",
+      "directive": "use client",
+      "imports": [
+        "lib/query-client.ts"
+      ],
+      "external": [
+        "@tanstack/react-query",
+        "@tanstack/react-query-devtools",
+        "react"
+      ]
+    },
+    {
+      "id": "services/api/analytics.ts",
+      "directive": null,
+      "imports": [
+        "services/api/client.ts"
+      ],
+      "external": []
+    },
+    {
+      "id": "services/api/client.ts",
+      "directive": null,
+      "imports": [],
+      "external": [
+        "zod"
+      ]
+    },
+    {
+      "id": "services/api/heatmap.ts",
+      "directive": null,
+      "imports": [
+        "services/api/client.ts"
+      ],
+      "external": [
+        "zod"
+      ]
+    },
+    {
+      "id": "services/api/stats.ts",
+      "directive": null,
+      "imports": [
+        "services/api/client.ts"
+      ],
+      "external": [
+        "zod"
+      ]
+    }
+  ]
+}

--- a/lib/architecture-layout.test.ts
+++ b/lib/architecture-layout.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+
+import { buildArchitectureGraph, type ModuleRecord } from "./architecture";
+import {
+  createFrameTransform,
+  createSimulation,
+  settleSimulation,
+  stepSimulation,
+  transformX,
+  transformY,
+  type LayoutSettings,
+} from "./architecture-layout";
+
+const SETTINGS: LayoutSettings = {
+  iterations: 300,
+  idealDistanceScale: 1,
+  repulsion: 1,
+  attraction: 0.35,
+  centeringPull: 0.006,
+  isolatedPull: 12,
+  temperature: 0.06,
+  margin: 24,
+};
+
+const WIDTH = 900;
+const HEIGHT = 600;
+
+const mod = (id: string, imports: string[] = []): ModuleRecord => ({
+  id,
+  directive: null,
+  imports,
+  external: [],
+});
+
+const graphOf = (records: ModuleRecord[]) => buildArchitectureGraph(records).modules;
+
+const settled = (records: ModuleRecord[], seed = 1) =>
+  settleSimulation(
+    createSimulation(graphOf(records), WIDTH, HEIGHT, SETTINGS, seed),
+    SETTINGS,
+  );
+
+const distance = (
+  simulation: ReturnType<typeof settled>,
+  first: string,
+  second: string,
+): number => {
+  const a = simulation.nodes.find((node) => node.id === first);
+  const b = simulation.nodes.find((node) => node.id === second);
+  if (!a || !b) throw new Error(`Fant ikke ${first} eller ${second}.`);
+  return Math.hypot(a.x - b.x, a.y - b.y);
+};
+
+describe("createSimulation", () => {
+  it("gir samme layout for samme seed", () => {
+    const records = [
+      mod("app/page.tsx", ["lib/a.ts", "lib/b.ts"]),
+      mod("lib/a.ts", ["lib/b.ts"]),
+      mod("lib/b.ts"),
+      mod("components/Widget.tsx", ["lib/a.ts"]),
+    ];
+
+    const first = settled(records).nodes.map((node) => [node.x, node.y]);
+    const second = settled(records).nodes.map((node) => [node.x, node.y]);
+
+    expect(first).toEqual(second);
+  });
+
+  it("gir ulik layout for ulikt seed", () => {
+    const records = [mod("app/page.tsx", ["lib/a.ts"]), mod("lib/a.ts")];
+
+    expect(settled(records, 1).nodes.map((node) => node.x)).not.toEqual(
+      settled(records, 99).nodes.map((node) => node.x),
+    );
+  });
+
+  it("teller hvor mange som importerer hver fil", () => {
+    const simulation = settled([
+      mod("app/page.tsx", ["lib/delt.ts"]),
+      mod("components/Widget.tsx", ["lib/delt.ts"]),
+      mod("lib/delt.ts"),
+    ]);
+
+    const inDegrees = Object.fromEntries(
+      simulation.nodes.map((node) => [node.id, node.inDegree]),
+    );
+
+    expect(inDegrees).toEqual({
+      "app/page.tsx": 0,
+      "components/Widget.tsx": 0,
+      "lib/delt.ts": 2,
+    });
+  });
+
+  it("dropper kanter til filer som ikke er i grafen", () => {
+    const simulation = settled([mod("app/page.tsx", ["lib/finnes-ikke.ts"])]);
+
+    expect(simulation.edges).toEqual([]);
+  });
+});
+
+describe("stepSimulation", () => {
+  it("holder alle noder innenfor rammen", () => {
+    // Mange noder uten kanter er verste tilfelle: bare frastøtning, ingenting
+    // som holder dem sammen.
+    const records = Array.from({ length: 40 }, (_, index) => mod(`lib/fil-${index}.ts`));
+    const simulation = settled(records);
+
+    for (const node of simulation.nodes) {
+      expect(node.x).toBeGreaterThanOrEqual(SETTINGS.margin);
+      expect(node.x).toBeLessThanOrEqual(WIDTH - SETTINGS.margin);
+      expect(node.y).toBeGreaterThanOrEqual(SETTINGS.margin);
+      expect(node.y).toBeLessThanOrEqual(HEIGHT - SETTINGS.margin);
+    }
+  });
+
+  it("stabler ikke nodene oppå hverandre", () => {
+    // Regresjonstest. Første versjon brukte akkumulert hastighet med demping, og
+    // da ble nodene slynget ut i rammen og lagt i haug der klampingen stoppet
+    // dem: nærmeste par 0,0 px. En layout kan se ferdig ut og likevel være
+    // ubrukelig, så avstanden må måles og ikke øyemåles.
+    const records = Array.from({ length: 40 }, (_, index) =>
+      mod(`${index % 2 === 0 ? "lib" : "components"}/fil-${index}.ts`),
+    );
+    const simulation = settled(records);
+
+    let closest = Infinity;
+    for (let first = 0; first < simulation.nodes.length; first += 1) {
+      for (let second = first + 1; second < simulation.nodes.length; second += 1) {
+        const a = simulation.nodes[first];
+        const b = simulation.nodes[second];
+        closest = Math.min(closest, Math.hypot(a.x - b.x, a.y - b.y));
+      }
+    }
+
+    expect(closest).toBeGreaterThan(15);
+  });
+
+  it("gir aldri NaN, heller ikke når to noder starter oppå hverandre", () => {
+    const records = [mod("lib/a.ts"), mod("lib/b.ts")];
+    const simulation = createSimulation(graphOf(records), WIDTH, HEIGHT, SETTINGS, 1);
+    // Tvinger fram delingen på null som EPSILON skal beskytte mot.
+    simulation.nodes[1].x = simulation.nodes[0].x;
+    simulation.nodes[1].y = simulation.nodes[0].y;
+
+    settleSimulation(simulation, SETTINGS);
+
+    for (const node of simulation.nodes) {
+      expect(Number.isFinite(node.x)).toBe(true);
+      expect(Number.isFinite(node.y)).toBe(true);
+    }
+  });
+
+  it("trekker filer som importerer hverandre nærmere enn filer uten kant", () => {
+    const records = [
+      mod("lib/knyttet-a.ts", ["lib/knyttet-b.ts"]),
+      mod("lib/knyttet-b.ts"),
+      mod("lib/alene-a.ts"),
+      mod("lib/alene-b.ts"),
+    ];
+    const simulation = settled(records);
+
+    expect(distance(simulation, "lib/knyttet-a.ts", "lib/knyttet-b.ts")).toBeLessThan(
+      distance(simulation, "lib/alene-a.ts", "lib/alene-b.ts"),
+    );
+  });
+
+  it("teller stegene, så avkjølingen vet hvor langt den har kommet", () => {
+    const simulation = createSimulation(graphOf([mod("lib/a.ts")]), WIDTH, HEIGHT, SETTINGS);
+    expect(simulation.step).toBe(0);
+
+    stepSimulation(simulation, SETTINGS);
+    expect(simulation.step).toBe(1);
+  });
+
+  it("faller til ro, altså beveger seg mindre mot slutten enn i starten", () => {
+    const records = [
+      mod("app/page.tsx", ["lib/a.ts", "lib/b.ts"]),
+      mod("components/Widget.tsx", ["lib/a.ts"]),
+      mod("lib/a.ts", ["lib/b.ts"]),
+      mod("lib/b.ts"),
+      mod("services/api/client.ts"),
+    ];
+
+    const movement = (simulation: ReturnType<typeof settled>) => {
+      const before = simulation.nodes.map((node) => ({ x: node.x, y: node.y }));
+      stepSimulation(simulation, SETTINGS);
+      return simulation.nodes.reduce(
+        (total, node, index) => total + Math.hypot(node.x - before[index].x, node.y - before[index].y),
+        0,
+      );
+    };
+
+    const simulation = createSimulation(graphOf(records), WIDTH, HEIGHT, SETTINGS, 1);
+    stepSimulation(simulation, SETTINGS);
+    const early = movement(simulation);
+
+    while (simulation.step < SETTINGS.iterations - 1) stepSimulation(simulation, SETTINGS);
+    const late = movement(simulation);
+
+    expect(late).toBeLessThan(early);
+  });
+});
+
+describe("createFrameTransform", () => {
+  const records = [
+    mod("app/page.tsx", ["lib/a.ts", "lib/b.ts"]),
+    mod("components/Widget.tsx", ["lib/a.ts"]),
+    mod("lib/a.ts", ["lib/b.ts"]),
+    mod("lib/b.ts"),
+    mod("services/api/client.ts"),
+    mod("providers/Provider.tsx"),
+  ];
+
+  it("fyller rammen i begge retninger", () => {
+    const simulation = settled(records);
+    const transform = createFrameTransform(simulation, SETTINGS);
+    const xs = simulation.nodes.map((node) => transformX(transform, node.x));
+    const ys = simulation.nodes.map((node) => transformY(transform, node.y));
+
+    expect(Math.min(...xs)).toBeCloseTo(SETTINGS.margin, 5);
+    expect(Math.max(...xs)).toBeCloseTo(WIDTH - SETTINGS.margin, 5);
+    expect(Math.min(...ys)).toBeCloseTo(SETTINGS.margin, 5);
+    expect(Math.max(...ys)).toBeCloseTo(HEIGHT - SETTINGS.margin, 5);
+  });
+
+  it("beholder rekkefølgen på aksene, altså snur ikke grafen", () => {
+    const simulation = settled(records);
+    const transform = createFrameTransform(simulation, SETTINGS);
+    const sorted = [...simulation.nodes].sort((first, second) => first.x - second.x);
+
+    const transformed = sorted.map((node) => transformX(transform, node.x));
+    for (let index = 1; index < transformed.length; index += 1) {
+      expect(transformed[index]).toBeGreaterThanOrEqual(transformed[index - 1]);
+    }
+  });
+
+  it("er identitet for under to noder, der en ramme ikke er definert", () => {
+    const simulation = settled([mod("lib/alene.ts")]);
+    const transform = createFrameTransform(simulation, SETTINGS);
+
+    expect(transform).toEqual({ scaleX: 1, scaleY: 1, offsetX: 0, offsetY: 0 });
+  });
+
+  it("gir ikke NaN når alle nodene ligger på samme punkt", () => {
+    const simulation = settled([mod("lib/a.ts"), mod("lib/b.ts")]);
+    for (const node of simulation.nodes) {
+      node.x = 100;
+      node.y = 100;
+    }
+    const transform = createFrameTransform(simulation, SETTINGS);
+
+    expect(Number.isFinite(transformX(transform, 100))).toBe(true);
+    expect(Number.isFinite(transformY(transform, 100))).toBe(true);
+  });
+});
+
+describe("settleSimulation", () => {
+  it("kjører til iterasjonsgrensen", () => {
+    const simulation = settled([mod("lib/a.ts"), mod("lib/b.ts", ["lib/a.ts"])]);
+    expect(simulation.step).toBe(SETTINGS.iterations);
+  });
+
+  it("tåler en tom graf", () => {
+    const simulation = createSimulation([], WIDTH, HEIGHT, SETTINGS);
+    expect(() => settleSimulation(simulation, SETTINGS)).not.toThrow();
+    expect(simulation.nodes).toEqual([]);
+  });
+
+  it("tåler én node uten kanter", () => {
+    const simulation = settled([mod("lib/alene.ts")]);
+    expect(simulation.nodes).toHaveLength(1);
+    expect(Number.isFinite(simulation.nodes[0].x)).toBe(true);
+  });
+});

--- a/lib/architecture-layout.test.ts
+++ b/lib/architecture-layout.test.ts
@@ -136,6 +136,46 @@ describe("stepSimulation", () => {
     expect(closest).toBeGreaterThan(15);
   });
 
+  it("frastøter etter 1/d², ikke etter 1/d", () => {
+    // Fruchterman-Reingold oppgir k²/d. Denne layouten bruker k²/d² med vilje,
+    // og forskjellen er målbar: k²/d ga 18,1 px minsteavstand på den ekte
+    // grafen på sitt aller beste, mot 34,0 px for k²/d². Uten denne testen er
+    // det bare en kommentar som skiller de to, og en kommentar stopper ingen
+    // fra å «rette» formelen tilbake til læreboka.
+    //
+    // Ingen sentertrekk og ingen kanter, så det eneste som flytter noden er
+    // frastøtningen fra den andre. Temperaturen settes høyt nok til at
+    // klampen ikke slår inn: ellers ville begge kraftlovene endt på samme
+    // maksflytt, og da måler testen klampen istedenfor formelen.
+    const settings: LayoutSettings = { ...SETTINGS, centeringPull: 0, temperature: 5 };
+
+    const displacementAt = (separation: number): number => {
+      const simulation = createSimulation(
+        graphOf([mod("lib/a.ts"), mod("lib/b.ts")]),
+        WIDTH,
+        HEIGHT,
+        settings,
+        1,
+      );
+      const [a, b] = simulation.nodes;
+      a.x = WIDTH / 2 - separation / 2;
+      b.x = WIDTH / 2 + separation / 2;
+      a.y = HEIGHT / 2;
+      b.y = HEIGHT / 2;
+
+      const startX = a.x;
+      stepSimulation(simulation, settings);
+      return Math.abs(a.x - startX);
+    };
+
+    // Dobbelt så langt unna skal gi en fjerdedel av kraften. Halvparten ville
+    // betydd k²/d.
+    const near = displacementAt(100);
+    const far = displacementAt(200);
+
+    expect(near / far).toBeCloseTo(4, 1);
+  });
+
   it("gir aldri NaN, heller ikke når to noder starter oppå hverandre", () => {
     const records = [mod("lib/a.ts"), mod("lib/b.ts")];
     const simulation = createSimulation(graphOf(records), WIDTH, HEIGHT, SETTINGS, 1);

--- a/lib/architecture-layout.ts
+++ b/lib/architecture-layout.ts
@@ -181,8 +181,15 @@ export function stepSimulation(simulation: Simulation, settings: LayoutSettings)
     node.displacementY = 0;
   }
 
-  // Frastøtning: k² / d. Faller av langsommere enn 1/d², så en node som havner
-  // nær en annen blir skjøvet bestemt unna uten å bli katapultert.
+  // Frastøtning: k² / d². Merk at dette ikke er k² / d, som er formelen
+  // Fruchterman-Reingold faktisk oppgir - avviket er målt og bevisst.
+  //
+  // Ekte FR er rundt 91 ganger sterkere ved typisk avstand, så summen over de
+  // 92 andre nodene treffer temperaturklampen og retningen blir det eneste som
+  // betyr noe. Målt på denne grafen ga k²/d 18,1 px minsteavstand på sitt aller
+  // beste, mens k²/d² gir 34,0 px og null par tettere enn 14 px. 1/d² faller
+  // raskere med avstanden, og det er den korte avstanden som avgjør om to
+  // sirkler overlapper. `stepSimulation`-testen låser forholdet.
   for (let first = 0; first < nodes.length; first += 1) {
     for (let second = first + 1; second < nodes.length; second += 1) {
       const a = nodes[first];

--- a/lib/architecture-layout.ts
+++ b/lib/architecture-layout.ts
@@ -1,0 +1,321 @@
+/**
+ * Kraftbasert plassering av importgrafen, etter Fruchterman-Reingold.
+ *
+ * Seedet, og derfor deterministisk: grafen ser like ut ved hver lasting, og
+ * layouten kan testes. En arkitekturgraf som stokker om på seg selv mellom to
+ * besøk er dessuten vanskeligere å kjenne igjen enn en som står stille.
+ *
+ * Valget av algoritme er ikke tilfeldig. Et første forsøk med akkumulert
+ * hastighet og demping endte med at nodene ble slynget ut i rammen og stablet
+ * seg oppå hverandre der klampingen holdt dem fast - 45 nodepar nærmere enn
+ * 14 px, og nærmeste par på 0,0 px. Fruchterman-Reingold har ingen hastighet:
+ * hvert steg regner ut et forflytning fra bunnen av og begrenser det til en
+ * temperatur som synker mot null. Da kan ikke energi bygge seg opp over tid.
+ *
+ * Simuleringen er delt i `createSimulation` og `stepSimulation` for at
+ * komponenten skal kunne velge: animere at grafen faller til ro, eller hoppe
+ * rett til sluttresultatet når `prefers-reduced-motion` er satt.
+ */
+
+import { LAYERS, type ArchitectureModule, type Layer } from "./architecture";
+
+export type LayoutNode = {
+  id: string;
+  layer: Layer;
+  /** Antall filer som importerer denne. Brukes til nodestørrelse. */
+  inDegree: number;
+  /** Antall kanter som berører noden, i begge retninger. 0 = helt isolert. */
+  degree: number;
+  x: number;
+  y: number;
+  displacementX: number;
+  displacementY: number;
+};
+
+export type LayoutEdge = {
+  from: string;
+  to: string;
+};
+
+export type Simulation = {
+  nodes: LayoutNode[];
+  edges: LayoutEdge[];
+  width: number;
+  height: number;
+  step: number;
+  /** Idealavstanden mellom to noder, regnet ut fra flate og nodeantall. */
+  idealDistance: number;
+};
+
+export type LayoutSettings = {
+  /** Antall steg før grafen regnes som falt til ro. */
+  iterations: number;
+  /** Ganges med sqrt(flate / noder). Under 1 gir en tettere graf. */
+  idealDistanceScale: number;
+  repulsion: number;
+  attraction: number;
+  /**
+   * Hvor hardt hver node trekkes mot midten.
+   *
+   * Første versjon trakk mot et anker per lag, plassert på en ellipse. Det ble
+   * fjernet fordi det ikke virket: målt lagskille var 18 px, altså ingen synlig
+   * gruppering, mens ankeret på ellipsens ytterpunkt spikret de isolerte filene
+   * ytterst i rammen og dro bounding boxen med seg. Lagene formidles av lista
+   * under grafen; klyngene får kantene bestemme.
+   */
+  centeringPull: number;
+  /**
+   * Ganges med `centeringPull` for noder uten en eneste kant.
+   *
+   * En isolert fil har ingen tiltrekning som balanserer frastøtningen, så uten
+   * dette blir den skjøvet ut i rammen og ligger alene i et hjørne. Det er ikke
+   * informasjon, bare en artefakt av at ingenting holder den igjen.
+   */
+  isolatedPull: number;
+  /** Største flytt per steg ved start, som andel av korteste side. Synker til 0. */
+  temperature: number;
+  margin: number;
+};
+
+/**
+ * mulberry32. Liten, rask og fullstendig bestemt av seedet.
+ *
+ * `Math.random` kan ikke brukes: uten kontroll på tallrekka er verken
+ * determinisme eller tester mulig.
+ */
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = Math.imul(state ^ (state >>> 15), 1 | state);
+    value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Vinkelen midt i lagets sektor. Brukes bare til å spre startposisjonene. */
+function layerAngle(layer: Layer): number {
+  const index = LAYERS.indexOf(layer);
+  return (index / LAYERS.length) * Math.PI * 2;
+}
+
+/**
+ * Startposisjoner: hvert lag på sin egen sektor av en ring rundt midten, med
+ * seedet spredning innenfor sektoren.
+ *
+ * Å starte sortert framfor tilfeldig gjør at simuleringen ikke må jobbe seg ut
+ * av en floke først, og at lagene fortsatt er til å kjenne igjen når den har
+ * falt til ro.
+ */
+export function createSimulation(
+  modules: readonly ArchitectureModule[],
+  width: number,
+  height: number,
+  settings: LayoutSettings,
+  seed = 1,
+): Simulation {
+  const random = createRandom(seed);
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const sector = (Math.PI * 2) / LAYERS.length;
+  const known = new Set(modules.map((record) => record.id));
+
+  const inDegrees = new Map<string, number>();
+  const degrees = new Map<string, number>();
+  const bump = (map: Map<string, number>, id: string) =>
+    map.set(id, (map.get(id) ?? 0) + 1);
+
+  for (const record of modules) {
+    for (const dependency of record.imports) {
+      if (!known.has(dependency)) continue;
+      bump(inDegrees, dependency);
+      bump(degrees, dependency);
+      bump(degrees, record.id);
+    }
+  }
+
+  const nodes = modules.map((record): LayoutNode => {
+    const angle = layerAngle(record.layer) + (random() - 0.5) * sector * 0.9;
+    const spread = 0.5 + random() * 0.7;
+    return {
+      id: record.id,
+      layer: record.layer,
+      inDegree: inDegrees.get(record.id) ?? 0,
+      degree: degrees.get(record.id) ?? 0,
+      x: centerX + Math.cos(angle) * width * 0.3 * spread,
+      y: centerY + Math.sin(angle) * height * 0.32 * spread,
+      displacementX: 0,
+      displacementY: 0,
+    };
+  });
+
+  const edges = modules.flatMap((record) =>
+    record.imports
+      .filter((dependency) => known.has(dependency))
+      .map((dependency): LayoutEdge => ({ from: record.id, to: dependency })),
+  );
+
+  // sqrt(flate / noder) er FR-idealavstanden: den fyller flaten uten å klumpe.
+  const idealDistance =
+    settings.idealDistanceScale *
+    Math.sqrt((width * height) / Math.max(1, nodes.length));
+
+  return { nodes, edges, width, height, step: 0, idealDistance };
+}
+
+/** Unngår deling på null når to noder havner oppå hverandre. */
+const EPSILON = 0.01;
+
+/**
+ * Ett steg av simuleringen. Muterer posisjonene i `simulation`.
+ *
+ * Frastøtning mellom alle par er O(n²), men n er antallet filer i repoet - noen
+ * få hundre i verste fall - så et kvadtre ville vært kompleksitet uten gevinst.
+ */
+export function stepSimulation(simulation: Simulation, settings: LayoutSettings): Simulation {
+  const { nodes, edges, width, height, idealDistance } = simulation;
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+
+  for (const node of nodes) {
+    node.displacementX = 0;
+    node.displacementY = 0;
+  }
+
+  // Frastøtning: k² / d. Faller av langsommere enn 1/d², så en node som havner
+  // nær en annen blir skjøvet bestemt unna uten å bli katapultert.
+  for (let first = 0; first < nodes.length; first += 1) {
+    for (let second = first + 1; second < nodes.length; second += 1) {
+      const a = nodes[first];
+      const b = nodes[second];
+      const deltaX = a.x - b.x;
+      const deltaY = a.y - b.y;
+      const distance = Math.max(EPSILON, Math.hypot(deltaX, deltaY));
+      const force =
+        (settings.repulsion * idealDistance * idealDistance) / distance / distance;
+      const pushX = (deltaX / distance) * force;
+      const pushY = (deltaY / distance) * force;
+
+      a.displacementX += pushX;
+      a.displacementY += pushY;
+      b.displacementX -= pushX;
+      b.displacementY -= pushY;
+    }
+  }
+
+  // Tiltrekning langs kantene: d² / k.
+  for (const edge of edges) {
+    const from = byId.get(edge.from);
+    const to = byId.get(edge.to);
+    if (!from || !to) continue;
+
+    const deltaX = to.x - from.x;
+    const deltaY = to.y - from.y;
+    const distance = Math.max(EPSILON, Math.hypot(deltaX, deltaY));
+    const force = (settings.attraction * distance * distance) / idealDistance;
+    const pullX = (deltaX / distance) * force;
+    const pullY = (deltaY / distance) * force;
+
+    from.displacementX += pullX;
+    from.displacementY += pullY;
+    to.displacementX -= pullX;
+    to.displacementY -= pullY;
+  }
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+  for (const node of nodes) {
+    const pull =
+      node.degree === 0
+        ? settings.centeringPull * settings.isolatedPull
+        : settings.centeringPull;
+    node.displacementX += (centerX - node.x) * pull;
+    node.displacementY += (centerY - node.y) * pull;
+  }
+
+  // Temperaturen synker lineært mot null. Det er dette - og ikke demping - som
+  // gjør at grafen faller til ro istedenfor å svinge.
+  const progress = Math.min(1, simulation.step / Math.max(1, settings.iterations));
+  const maxStep = settings.temperature * Math.min(width, height) * (1 - progress);
+
+  for (const node of nodes) {
+    const magnitude = Math.hypot(node.displacementX, node.displacementY);
+    if (magnitude > EPSILON) {
+      const limited = Math.min(magnitude, maxStep) / magnitude;
+      node.x += node.displacementX * limited;
+      node.y += node.displacementY * limited;
+    }
+
+    // Innenfor rammen. Sikkerhetsnett: temperaturen skal normalt holde nodene
+    // inne på egen hånd.
+    node.x = Math.min(width - settings.margin, Math.max(settings.margin, node.x));
+    node.y = Math.min(height - settings.margin, Math.max(settings.margin, node.y));
+  }
+
+  simulation.step += 1;
+  return simulation;
+}
+
+/**
+ * Skalering og forskyvning som får grafen til å fylle rammen.
+ *
+ * En kraftbasert graf legger seg naturlig i en rund klump, og en rund klump i et
+ * liggende format lar en tredjedel av bredden stå tom. Å presse simuleringen til
+ * å bli bred i stedet gjorde det bare verre - sterkere lagtrekk komprimerte den
+ * (44 % til 34 % av bredden), for ankerringen er mindre enn klumpen vil være.
+ *
+ * Derfor skilles simuleringskoordinater fra det som males. Simuleringen får
+ * legge seg som den vil, og transformen strekker resultatet ut i rammen. x og y
+ * skaleres uavhengig: en graf har ingen målestokk, så det at avstander forvrenges
+ * betyr ingenting - men det ville betydd noe for nodestørrelser og tekst, og
+ * derfor er dette ikke en `transform` på SVG-en. Bare posisjoner sendes gjennom.
+ */
+export type FrameTransform = {
+  scaleX: number;
+  scaleY: number;
+  offsetX: number;
+  offsetY: number;
+};
+
+export function createFrameTransform(
+  simulation: Simulation,
+  settings: LayoutSettings,
+): FrameTransform {
+  const identity: FrameTransform = { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: 0 };
+  if (simulation.nodes.length < 2) return identity;
+
+  const xs = simulation.nodes.map((node) => node.x);
+  const ys = simulation.nodes.map((node) => node.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const spanX = Math.max(EPSILON, Math.max(...xs) - minX);
+  const spanY = Math.max(EPSILON, Math.max(...ys) - minY);
+
+  const targetWidth = simulation.width - settings.margin * 2;
+  const targetHeight = simulation.height - settings.margin * 2;
+  const scaleX = targetWidth / spanX;
+  const scaleY = targetHeight / spanY;
+
+  return {
+    scaleX,
+    scaleY,
+    offsetX: settings.margin - minX * scaleX,
+    offsetY: settings.margin - minY * scaleY,
+  };
+}
+
+export function transformX(transform: FrameTransform, x: number): number {
+  return x * transform.scaleX + transform.offsetX;
+}
+
+export function transformY(transform: FrameTransform, y: number): number {
+  return y * transform.scaleY + transform.offsetY;
+}
+
+/** Kjører simuleringen ferdig. Brukes når bevegelsen ikke skal vises. */
+export function settleSimulation(
+  simulation: Simulation,
+  settings: LayoutSettings,
+): Simulation {
+  while (simulation.step < settings.iterations) stepSimulation(simulation, settings);
+  return simulation;
+}

--- a/lib/architecture.test.ts
+++ b/lib/architecture.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildArchitectureGraph,
+  clientClosure,
+  layerOf,
+  type ModuleRecord,
+} from "./architecture";
+
+const mod = (
+  id: string,
+  imports: string[] = [],
+  directive: string | null = null,
+): ModuleRecord => ({ id, directive, imports, external: [] });
+
+describe("layerOf", () => {
+  it("leser laget av første stikomponent", () => {
+    expect(layerOf("components/home/BentoGrid.tsx")).toBe("components");
+    expect(layerOf("lib/mst.ts")).toBe("lib");
+    expect(layerOf("services/api/client.ts")).toBe("services");
+  });
+
+  it("kaster på ukjent toppmappe istedenfor å gjette", () => {
+    expect(() => layerOf("utils/helper.ts")).toThrow(/utils\/helper\.ts/);
+  });
+});
+
+describe("clientClosure", () => {
+  it("tar med filer uten direktiv som en klientkomponent importerer", () => {
+    const modules = [
+      mod("components/Widget.tsx", ["lib/format.ts"], "use client"),
+      mod("lib/format.ts"),
+    ];
+
+    expect(clientClosure(modules)).toEqual(
+      new Set(["components/Widget.tsx", "lib/format.ts"]),
+    );
+  });
+
+  it("holder serverkode utenfor når ingen klientfil når den", () => {
+    const modules = [
+      mod("app/page.tsx", ["lib/flags.ts"]),
+      mod("lib/flags.ts"),
+      mod("components/Widget.tsx", [], "use client"),
+    ];
+
+    expect(clientClosure(modules).has("lib/flags.ts")).toBe(false);
+  });
+
+  it("følger importer flere nivåer ned", () => {
+    const modules = [
+      mod("components/Widget.tsx", ["lib/a.ts"], "use client"),
+      mod("lib/a.ts", ["lib/b.ts"]),
+      mod("lib/b.ts", ["lib/c.ts"]),
+      mod("lib/c.ts"),
+    ];
+
+    expect(clientClosure(modules).size).toBe(4);
+  });
+
+  it("terminerer på importsykluser", () => {
+    const modules = [
+      mod("components/Widget.tsx", ["lib/a.ts"], "use client"),
+      mod("lib/a.ts", ["lib/b.ts"]),
+      mod("lib/b.ts", ["lib/a.ts"]),
+    ];
+
+    expect(clientClosure(modules)).toEqual(
+      new Set(["components/Widget.tsx", "lib/a.ts", "lib/b.ts"]),
+    );
+  });
+
+  it("terminerer når en fil importerer seg selv", () => {
+    const modules = [mod("components/Widget.tsx", ["components/Widget.tsx"], "use client")];
+
+    expect(clientClosure(modules)).toEqual(new Set(["components/Widget.tsx"]));
+  });
+
+  it("regner en delt fil som klient så snart én klientfil når den", () => {
+    const modules = [
+      mod("app/page.tsx", ["lib/shared.ts"]),
+      mod("components/Widget.tsx", ["lib/shared.ts"], "use client"),
+      mod("lib/shared.ts"),
+    ];
+
+    expect(clientClosure(modules).has("lib/shared.ts")).toBe(true);
+  });
+
+  it("stopper på use server, som ikke krysser over til nettleseren", () => {
+    const modules = [
+      mod("components/Form.tsx", ["app/actions.ts"], "use client"),
+      mod("app/actions.ts", ["lib/db.ts"], "use server"),
+      mod("lib/db.ts"),
+    ];
+
+    const closure = clientClosure(modules);
+    expect(closure.has("app/actions.ts")).toBe(false);
+    expect(closure.has("lib/db.ts")).toBe(false);
+  });
+
+  it("tåler importer til filer som ikke er skannet", () => {
+    const modules = [mod("components/Widget.tsx", ["lib/mangler.ts"], "use client")];
+
+    expect(() => clientClosure(modules)).not.toThrow();
+  });
+});
+
+describe("buildArchitectureGraph", () => {
+  it("sorterer moduler og importer deterministisk", () => {
+    const graph = buildArchitectureGraph([
+      mod("lib/z.ts"),
+      mod("app/page.tsx", ["lib/z.ts", "lib/a.ts"]),
+      mod("lib/a.ts"),
+    ]);
+
+    expect(graph.modules.map((record) => record.id)).toEqual([
+      "app/page.tsx",
+      "lib/a.ts",
+      "lib/z.ts",
+    ]);
+    expect(graph.modules[0].imports).toEqual(["lib/a.ts", "lib/z.ts"]);
+  });
+
+  it("merker runtime ut fra nåbarhet, ikke ut fra direktivet", () => {
+    const graph = buildArchitectureGraph([
+      mod("components/Widget.tsx", ["lib/delt.ts"], "use client"),
+      mod("lib/delt.ts"),
+      mod("app/page.tsx"),
+    ]);
+
+    const runtimes = Object.fromEntries(
+      graph.modules.map((record) => [record.id, record.runtime]),
+    );
+
+    expect(runtimes).toEqual({
+      "app/page.tsx": "server",
+      "components/Widget.tsx": "client",
+      "lib/delt.ts": "client",
+    });
+  });
+});

--- a/lib/architecture.ts
+++ b/lib/architecture.ts
@@ -1,0 +1,111 @@
+/**
+ * Modellen bak arkitekturgrafen: hvilke filer importerer hvilke, og hvilke av
+ * dem havner faktisk i nettleserbunten.
+ *
+ * Ren logikk uten filsystem og uten TypeScript-kompilatoren. Uthentingen av
+ * importer bor i `scripts/architecture/scan.ts`; her er bare grafen. Det gjør
+ * lukningen testbar på små, håndskrevne grafer istedenfor på repoet selv.
+ */
+
+export const LAYERS = ["app", "components", "lib", "providers", "services"] as const;
+
+export type Layer = (typeof LAYERS)[number];
+
+/** Hvor koden ender opp, ikke hvor den er skrevet. */
+export type Runtime = "server" | "client";
+
+/**
+ * En fil slik skanneren ser den. `imports` er interne, repo-relative stier;
+ * `external` er pakkespesifikasjoner (`react`, `next/image`) som ikke løses opp
+ * til filer i repoet.
+ */
+export type ModuleRecord = {
+  id: string;
+  directive: string | null;
+  imports: string[];
+  external: string[];
+};
+
+export type ArchitectureModule = ModuleRecord & {
+  layer: Layer;
+  runtime: Runtime;
+};
+
+export type ArchitectureGraph = {
+  modules: ArchitectureModule[];
+};
+
+export function isLayer(value: string): value is Layer {
+  return (LAYERS as readonly string[]).includes(value);
+}
+
+/**
+ * Laget er første stikomponent. Kaster på ukjent lag framfor å finne opp en
+ * `"other"`-bøtte: en ny toppmappe er en arkitekturendring som skal ses av et
+ * menneske, ikke havne stille i en samlekategori.
+ */
+export function layerOf(id: string): Layer {
+  const [first] = id.split("/");
+  if (!isLayer(first)) {
+    throw new Error(`Fant ingen kjent lag for "${id}". Legg laget til i LAYERS.`);
+  }
+  return first;
+}
+
+/**
+ * Transitiv lukning fra hver `"use client"`-fil.
+ *
+ * Poenget: en fil uten `"use client"` shipper likevel til nettleseren hvis en
+ * klientkomponent importerer den. Det er ikke direktivet som avgjør hvor koden
+ * havner, det er nåbarheten. Derfor er det denne mengden - ikke antallet
+ * `"use client"`-filer - som sier hva brukeren faktisk laster ned.
+ *
+ * `"use server"` stopper vandringen. Et server action kan kalles fra klienten,
+ * men koden krysser aldri over; å regne den som klientkode ville overdrevet
+ * bunten. Filen selv tas heller ikke med.
+ */
+export function clientClosure(modules: readonly ModuleRecord[]): Set<string> {
+  const byId = new Map(modules.map((record) => [record.id, record]));
+  const closure = new Set<string>();
+  const pending = modules
+    .filter((record) => record.directive === "use client")
+    .map((record) => record.id);
+
+  while (pending.length > 0) {
+    const id = pending.pop() as string;
+    // Importsykluser er lovlige i JavaScript, så vandringen må tåle dem.
+    if (closure.has(id)) continue;
+
+    const record = byId.get(id);
+    if (record?.directive === "use server") continue;
+
+    closure.add(id);
+    for (const dependency of record?.imports ?? []) pending.push(dependency);
+  }
+
+  return closure;
+}
+
+/**
+ * Sorterer deterministisk. Grafen sjekkes inn, så en stabil rekkefølge er det
+ * som gjør diffen lesbar: da viser den arkitekturendringen og ikke støy fra
+ * hvilken rekkefølge filsystemet svarte i.
+ */
+export function buildArchitectureGraph(modules: readonly ModuleRecord[]): ArchitectureGraph {
+  const closure = clientClosure(modules);
+
+  const modulesWithRuntime = modules.map((record): ArchitectureModule => {
+    const runtime: Runtime = closure.has(record.id) ? "client" : "server";
+    return {
+      ...record,
+      imports: [...record.imports].sort(),
+      external: [...record.external].sort(),
+      layer: layerOf(record.id),
+      runtime,
+    };
+  });
+
+  return {
+    modules: modulesWithRuntime.sort((first, second) => first.id.localeCompare(second.id)),
+  };
+}

--- a/scripts/architecture-graph.ts
+++ b/scripts/architecture-graph.ts
@@ -12,240 +12,24 @@
  * skjer usett. `architecture-rules.test.ts` feiler hvis den innsjekkede filen er
  * utdatert, så den kan ikke bli liggende igjen i en gammel tilstand.
  *
- * Bare rå fakta lagres - hvilke filer finnes og hva de importerer. Om en fil
- * ender opp på server eller klient regnes ut av `lib/architecture.ts`, så den
- * avledningen finnes på ett sted og er dekket av tester.
- *
- * Skanning og skriving ligger i samme fil med vilje. Et kall over filgrensen
- * hadde måttet være en verdi-import, og der er `node` og `tsc` uenige: `node`
- * krever `.ts`-endelsen, `tsc` forbyr den uten `allowImportingTsExtensions`.
- * `import.meta.main` løser det uten å røre tsconfig - modulen kan importeres av
- * testene uten at noe skrives, og skriver når filen kjøres direkte.
+ * Delene ligger i `scripts/architecture/`. Importene har `.ts`-endelse fordi
+ * `node` krever den; `allowImportingTsExtensions` i tsconfig er det som gjør at
+ * `tsc` godtar den samme stien.
  *
  * Kjører aldri i applikasjonen, så TypeScript-kompilatoren havner ikke i noen
  * bunt.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import { dirname, join, posix, relative, sep } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import ts from "typescript";
-
-// Type-only, og derfor gratis: Node stripper importen bort før kjøring, så
-// spesifikatoren trenger ingen filendelse.
-import type { ModuleRecord } from "../lib/architecture";
-
-export const GRAPH_FILE = "data/architecture-graph.json";
-
-/**
- * Mappene som utgjør applikasjonen.
- *
- * Duplisert fra `LAYERS` i `lib/architecture.ts` med vilje - se kommentaren over
- * om importer. `architecture-rules.test.ts` slår fast at de to listene er like,
- * så dupliseringen kan ikke drifte i stillhet.
- */
-export const SCANNED_DIRECTORIES = [
-  "app",
-  "components",
-  "lib",
-  "providers",
-  "services",
-] as const;
-
-const SOURCE_FILE = /\.tsx?$/;
-const TEST_FILE = /\.test\.tsx?$/;
-const DECLARATION_FILE = /\.d\.ts$/;
-
-/** Rekkefølgen en bundler prøver når en spesifikator mangler filendelse. */
-const RESOLUTION_SUFFIXES = ["", ".ts", ".tsx", "/index.ts", "/index.tsx"];
-
-function toPosix(path: string): string {
-  return path.split(sep).join("/");
-}
-
-function collectSourceFiles(root: string, directory: string): string[] {
-  const absolute = join(root, directory);
-  if (!existsSync(absolute)) return [];
-
-  const found: string[] = [];
-  const visit = (current: string) => {
-    for (const entry of readdirSync(current)) {
-      const full = join(current, entry);
-      if (statSync(full).isDirectory()) {
-        visit(full);
-        continue;
-      }
-      // Tester og typedeklarasjoner er ikke en del av applikasjonsarkitekturen
-      // og shipper ikke, så de ville bare gjort grafen større uten å si noe.
-      if (!SOURCE_FILE.test(entry) || TEST_FILE.test(entry) || DECLARATION_FILE.test(entry)) {
-        continue;
-      }
-      found.push(toPosix(relative(root, full)));
-    }
-  };
-
-  visit(absolute);
-  return found;
-}
-
-type ParsedModule = {
-  specifiers: string[];
-  directive: string | null;
-};
-
-/**
- * Henter ut modulspesifikatorer og et eventuelt ledende direktiv.
- *
- * Bruker TypeScript-kompilatorens egen parser framfor regex. Det koster
- * ingenting - `typescript` ligger allerede i devDependencies - og det er
- * forskjellen på å finne alle importformene og å finne de fleste:
- * `export ... from`, `import type` og `await import()` ser ikke like ut for et
- * regex, men er alle ImportDeclaration/ExportDeclaration/ImportKeyword i AST-et.
- *
- * Direktivet må stå som første setning for at Next skal godta det, så vi leter
- * bare der. En `"use client"` lenger ned i filen er en vanlig streng, og skal
- * ikke tolkes som noe annet her heller.
- */
-export function parseModule(source: string, fileName: string): ParsedModule {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
-
-  const specifiers: string[] = [];
-  const visit = (node: ts.Node): void => {
-    if (
-      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
-      node.moduleSpecifier &&
-      ts.isStringLiteral(node.moduleSpecifier)
-    ) {
-      specifiers.push(node.moduleSpecifier.text);
-    }
-
-    if (
-      ts.isCallExpression(node) &&
-      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-      node.arguments.length > 0 &&
-      ts.isStringLiteral(node.arguments[0])
-    ) {
-      specifiers.push(node.arguments[0].text);
-    }
-
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(sourceFile, visit);
-
-  const [first] = sourceFile.statements;
-  const directive =
-    first && ts.isExpressionStatement(first) && ts.isStringLiteral(first.expression)
-      ? first.expression.text
-      : null;
-
-  return { specifiers, directive };
-}
-
-/**
- * Løser en spesifikator til en repo-relativ fil, eller `null` hvis den peker ut
- * av repoet. `@/` er aliaset i tsconfig og peker på repo-roten.
- */
-export function resolveSpecifier(
-  root: string,
-  fromFile: string,
-  specifier: string,
-): string | null {
-  let base: string;
-  if (specifier.startsWith("@/")) {
-    base = specifier.slice(2);
-  } else if (specifier.startsWith(".")) {
-    base = posix.normalize(posix.join(posix.dirname(toPosix(fromFile)), specifier));
-  } else {
-    return null;
-  }
-
-  for (const suffix of RESOLUTION_SUFFIXES) {
-    const candidate = `${base}${suffix}`;
-    const absolute = join(root, candidate);
-    if (existsSync(absolute) && statSync(absolute).isFile()) return candidate;
-  }
-
-  return null;
-}
-
-/** True for spesifikatorer som _skal_ peke internt, altså der et oppslag som feiler er en feil. */
-function isInternalSpecifier(specifier: string): boolean {
-  return specifier.startsWith("@/") || specifier.startsWith(".");
-}
-
-export type ScanResult = {
-  modules: ModuleRecord[];
-  /**
-   * Interne importer som ikke lot seg løse opp. Skal alltid være tom: en
-   * spesifikator som starter med `@/` eller `.` peker på en fil i repoet, og
-   * finner vi den ikke, har skanneren en blindsone. En ufullstendig graf som
-   * later som den er komplett er verre enn ingen graf.
-   */
-  unresolved: string[];
-};
-
-export function scanRepository(root: string): ScanResult {
-  const files = SCANNED_DIRECTORIES.flatMap((directory) => collectSourceFiles(root, directory));
-
-  const unresolved: string[] = [];
-  const modules = files.map((id): ModuleRecord => {
-    const { specifiers, directive } = parseModule(readFileSync(join(root, id), "utf8"), id);
-    const imports = new Set<string>();
-    const external = new Set<string>();
-
-    for (const specifier of specifiers) {
-      const resolved = resolveSpecifier(root, id, specifier);
-      if (resolved) {
-        // En fil som importerer seg selv er ikke en kant i grafen.
-        if (resolved !== id) imports.add(resolved);
-        continue;
-      }
-      if (isInternalSpecifier(specifier)) {
-        unresolved.push(`${id} -> ${specifier}`);
-        continue;
-      }
-      external.add(specifier);
-    }
-
-    return { id, directive, imports: [...imports], external: [...external] };
-  });
-
-  return { modules, unresolved };
-}
+import { scanRepository } from "./architecture/scan.ts";
+import { GRAPH_FILE, serializeGraph } from "./architecture/serialize.ts";
 
 /** Repo-roten, regnet ut fra denne filens plassering i `scripts/`. */
 export function repositoryRoot(): string {
   return join(dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-/** Med nøklene i fast rekkefølge, ellers blir diffen avhengig av objektlitteralet. */
-export function serializeGraph(modules: readonly ModuleRecord[]): string {
-  const payload = {
-    modules: [...modules]
-      .sort((first, second) => first.id.localeCompare(second.id))
-      .map((record) => ({
-        id: record.id,
-        directive: record.directive,
-        imports: [...record.imports].sort(),
-        external: [...record.external].sort(),
-      })),
-  };
-
-  return `${JSON.stringify(payload, null, 2)}\n`;
 }
 
 function main(): void {
@@ -266,4 +50,5 @@ function main(): void {
   console.log(`Skrev ${GRAPH_FILE}: ${modules.length} filer.`);
 }
 
+// Slik at testene kan importere `repositoryRoot` uten at noe skrives til disk.
 if (import.meta.main) main();

--- a/scripts/architecture-graph.ts
+++ b/scripts/architecture-graph.ts
@@ -1,0 +1,269 @@
+/**
+ * Leser importgrafen ut av kildekoden og skriver den til
+ * `data/architecture-graph.json`.
+ *
+ * Kjør etter at filer er lagt til, flyttet eller fått nye importer:
+ *
+ *   node scripts/architecture-graph.ts
+ *
+ * Filen sjekkes inn. Det er et bevisst valg framfor å generere den under bygget:
+ * da havner arkitekturendringen i diffen, og «denne klientkomponenten trekker
+ * plutselig inn tre nye moduler» blir noe en reviewer ser istedenfor noe som
+ * skjer usett. `architecture-rules.test.ts` feiler hvis den innsjekkede filen er
+ * utdatert, så den kan ikke bli liggende igjen i en gammel tilstand.
+ *
+ * Bare rå fakta lagres - hvilke filer finnes og hva de importerer. Om en fil
+ * ender opp på server eller klient regnes ut av `lib/architecture.ts`, så den
+ * avledningen finnes på ett sted og er dekket av tester.
+ *
+ * Skanning og skriving ligger i samme fil med vilje. Et kall over filgrensen
+ * hadde måttet være en verdi-import, og der er `node` og `tsc` uenige: `node`
+ * krever `.ts`-endelsen, `tsc` forbyr den uten `allowImportingTsExtensions`.
+ * `import.meta.main` løser det uten å røre tsconfig - modulen kan importeres av
+ * testene uten at noe skrives, og skriver når filen kjøres direkte.
+ *
+ * Kjører aldri i applikasjonen, så TypeScript-kompilatoren havner ikke i noen
+ * bunt.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, posix, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+// Type-only, og derfor gratis: Node stripper importen bort før kjøring, så
+// spesifikatoren trenger ingen filendelse.
+import type { ModuleRecord } from "../lib/architecture";
+
+export const GRAPH_FILE = "data/architecture-graph.json";
+
+/**
+ * Mappene som utgjør applikasjonen.
+ *
+ * Duplisert fra `LAYERS` i `lib/architecture.ts` med vilje - se kommentaren over
+ * om importer. `architecture-rules.test.ts` slår fast at de to listene er like,
+ * så dupliseringen kan ikke drifte i stillhet.
+ */
+export const SCANNED_DIRECTORIES = [
+  "app",
+  "components",
+  "lib",
+  "providers",
+  "services",
+] as const;
+
+const SOURCE_FILE = /\.tsx?$/;
+const TEST_FILE = /\.test\.tsx?$/;
+const DECLARATION_FILE = /\.d\.ts$/;
+
+/** Rekkefølgen en bundler prøver når en spesifikator mangler filendelse. */
+const RESOLUTION_SUFFIXES = ["", ".ts", ".tsx", "/index.ts", "/index.tsx"];
+
+function toPosix(path: string): string {
+  return path.split(sep).join("/");
+}
+
+function collectSourceFiles(root: string, directory: string): string[] {
+  const absolute = join(root, directory);
+  if (!existsSync(absolute)) return [];
+
+  const found: string[] = [];
+  const visit = (current: string) => {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      // Tester og typedeklarasjoner er ikke en del av applikasjonsarkitekturen
+      // og shipper ikke, så de ville bare gjort grafen større uten å si noe.
+      if (!SOURCE_FILE.test(entry) || TEST_FILE.test(entry) || DECLARATION_FILE.test(entry)) {
+        continue;
+      }
+      found.push(toPosix(relative(root, full)));
+    }
+  };
+
+  visit(absolute);
+  return found;
+}
+
+type ParsedModule = {
+  specifiers: string[];
+  directive: string | null;
+};
+
+/**
+ * Henter ut modulspesifikatorer og et eventuelt ledende direktiv.
+ *
+ * Bruker TypeScript-kompilatorens egen parser framfor regex. Det koster
+ * ingenting - `typescript` ligger allerede i devDependencies - og det er
+ * forskjellen på å finne alle importformene og å finne de fleste:
+ * `export ... from`, `import type` og `await import()` ser ikke like ut for et
+ * regex, men er alle ImportDeclaration/ExportDeclaration/ImportKeyword i AST-et.
+ *
+ * Direktivet må stå som første setning for at Next skal godta det, så vi leter
+ * bare der. En `"use client"` lenger ned i filen er en vanlig streng, og skal
+ * ikke tolkes som noe annet her heller.
+ */
+export function parseModule(source: string, fileName: string): ParsedModule {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  const [first] = sourceFile.statements;
+  const directive =
+    first && ts.isExpressionStatement(first) && ts.isStringLiteral(first.expression)
+      ? first.expression.text
+      : null;
+
+  return { specifiers, directive };
+}
+
+/**
+ * Løser en spesifikator til en repo-relativ fil, eller `null` hvis den peker ut
+ * av repoet. `@/` er aliaset i tsconfig og peker på repo-roten.
+ */
+export function resolveSpecifier(
+  root: string,
+  fromFile: string,
+  specifier: string,
+): string | null {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = specifier.slice(2);
+  } else if (specifier.startsWith(".")) {
+    base = posix.normalize(posix.join(posix.dirname(toPosix(fromFile)), specifier));
+  } else {
+    return null;
+  }
+
+  for (const suffix of RESOLUTION_SUFFIXES) {
+    const candidate = `${base}${suffix}`;
+    const absolute = join(root, candidate);
+    if (existsSync(absolute) && statSync(absolute).isFile()) return candidate;
+  }
+
+  return null;
+}
+
+/** True for spesifikatorer som _skal_ peke internt, altså der et oppslag som feiler er en feil. */
+function isInternalSpecifier(specifier: string): boolean {
+  return specifier.startsWith("@/") || specifier.startsWith(".");
+}
+
+export type ScanResult = {
+  modules: ModuleRecord[];
+  /**
+   * Interne importer som ikke lot seg løse opp. Skal alltid være tom: en
+   * spesifikator som starter med `@/` eller `.` peker på en fil i repoet, og
+   * finner vi den ikke, har skanneren en blindsone. En ufullstendig graf som
+   * later som den er komplett er verre enn ingen graf.
+   */
+  unresolved: string[];
+};
+
+export function scanRepository(root: string): ScanResult {
+  const files = SCANNED_DIRECTORIES.flatMap((directory) => collectSourceFiles(root, directory));
+
+  const unresolved: string[] = [];
+  const modules = files.map((id): ModuleRecord => {
+    const { specifiers, directive } = parseModule(readFileSync(join(root, id), "utf8"), id);
+    const imports = new Set<string>();
+    const external = new Set<string>();
+
+    for (const specifier of specifiers) {
+      const resolved = resolveSpecifier(root, id, specifier);
+      if (resolved) {
+        // En fil som importerer seg selv er ikke en kant i grafen.
+        if (resolved !== id) imports.add(resolved);
+        continue;
+      }
+      if (isInternalSpecifier(specifier)) {
+        unresolved.push(`${id} -> ${specifier}`);
+        continue;
+      }
+      external.add(specifier);
+    }
+
+    return { id, directive, imports: [...imports], external: [...external] };
+  });
+
+  return { modules, unresolved };
+}
+
+/** Repo-roten, regnet ut fra denne filens plassering i `scripts/`. */
+export function repositoryRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+/** Med nøklene i fast rekkefølge, ellers blir diffen avhengig av objektlitteralet. */
+export function serializeGraph(modules: readonly ModuleRecord[]): string {
+  const payload = {
+    modules: [...modules]
+      .sort((first, second) => first.id.localeCompare(second.id))
+      .map((record) => ({
+        id: record.id,
+        directive: record.directive,
+        imports: [...record.imports].sort(),
+        external: [...record.external].sort(),
+      })),
+  };
+
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+function main(): void {
+  const root = repositoryRoot();
+  const { modules, unresolved } = scanRepository(root);
+
+  if (unresolved.length > 0) {
+    console.error("Interne importer som ikke lot seg løse opp:");
+    for (const entry of unresolved) console.error(`  ${entry}`);
+    console.error("Grafen ville blitt ufullstendig. Fiks oppslaget i skannekoden først.");
+    process.exit(1);
+  }
+
+  const target = join(root, GRAPH_FILE);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, serializeGraph(modules));
+
+  console.log(`Skrev ${GRAPH_FILE}: ${modules.length} filer.`);
+}
+
+if (import.meta.main) main();

--- a/scripts/architecture-rules.test.ts
+++ b/scripts/architecture-rules.test.ts
@@ -53,6 +53,18 @@ describe("skanningen", () => {
     expect([...layers].sort()).toEqual([...LAYERS].sort());
   });
 
+  it("lager ingen kanter til filer som ikke er noder", () => {
+    // `app/globals.css` og `data/architecture-graph.json` løses opp fint, men
+    // de er ikke kildefiler og har ingen node. En kant til dem er en påstand om
+    // grafen som grafen selv motsier.
+    const ids = new Set(scan.modules.map((record) => record.id));
+    const dangling = scan.modules.flatMap((record) =>
+      record.imports.filter((id) => !ids.has(id)).map((id) => `${record.id} -> ${id}`),
+    );
+
+    expect(dangling).toEqual([]);
+  });
+
   it("skanner de samme mappene som grafen har lag for", () => {
     // Dupliseringen mellom SCANNED_DIRECTORIES og LAYERS er bevisst; denne
     // testen er prisen for den.
@@ -101,7 +113,14 @@ describe("server/klient-grensen", () => {
   });
 });
 
-/** Finner kall til `fetch(...)`, inkludert `globalThis.fetch(...)`, via AST-et. */
+/**
+ * Finner kall til den globale `fetch`, via AST-et.
+ *
+ * Bare `fetch(...)`, `globalThis.fetch(...)` og `window.fetch(...)` teller. Et
+ * hvilket som helst `.fetch()` ville også truffet metoder som tilfeldigvis
+ * heter det - en klient som eksponerer `api.fetch()` er ikke det regelen
+ * handler om.
+ */
 function findFetchCalls(source: string, fileName: string): number {
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -115,12 +134,16 @@ function findFetchCalls(source: string, fileName: string): number {
   const visit = (node: ts.Node): void => {
     if (ts.isCallExpression(node)) {
       const target = node.expression;
-      const name = ts.isIdentifier(target)
-        ? target.text
-        : ts.isPropertyAccessExpression(target)
-          ? target.name.text
-          : null;
-      if (name === "fetch") count += 1;
+      if (ts.isIdentifier(target) && target.text === "fetch") {
+        count += 1;
+      } else if (
+        ts.isPropertyAccessExpression(target) &&
+        target.name.text === "fetch" &&
+        ts.isIdentifier(target.expression) &&
+        (target.expression.text === "globalThis" || target.expression.text === "window")
+      ) {
+        count += 1;
+      }
     }
     ts.forEachChild(node, visit);
   };

--- a/scripts/architecture-rules.test.ts
+++ b/scripts/architecture-rules.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Arkitekturreglene i AGENTS.md, håndhevet.
+ *
+ * AGENTS.md sier selv at «required CI checks are the authoritative gate» og at
+ * håndhevbare regler skal ligge i ESLint eller tester. Reglene her er nettopp de
+ * som ikke kan uttrykkes i ESLint, fordi de handler om forholdet mellom filer og
+ * ikke om innholdet i én fil: hva som ender opp i nettleserbunten avgjøres av
+ * hvem som importerer hva, og det ser en per-fil-linter aldri.
+ *
+ * Kjører mot en fersk skanning, ikke mot den innsjekkede JSON-filen. Ellers
+ * kunne en regel «passeres» ved å redigere grafen istedenfor koden.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+import { LAYERS, clientClosure } from "../lib/architecture";
+import {
+  GRAPH_FILE,
+  SCANNED_DIRECTORIES,
+  repositoryRoot,
+  scanRepository,
+  serializeGraph,
+} from "./architecture-graph";
+
+const root = repositoryRoot();
+const scan = scanRepository(root);
+const closure = clientClosure(scan.modules);
+
+/**
+ * Moduler som aldri får havne i nettleserbunten, med grunnen til det.
+ *
+ * `lib/features.ts` leser `RUNNING_HEATMAP_ENABLED` uten `NEXT_PUBLIC_`-prefiks
+ * nettopp for at verdien ikke skal ut til klienten. Den intensjonen står som en
+ * kommentar i filen, og en kommentar hindrer ingenting: det holder at én
+ * `"use client"`-komponent importerer den, så er brytertilstanden offentlig.
+ * Derfor står den her.
+ */
+const SERVER_ONLY_MODULES: Record<string, string> = {
+  "lib/features.ts":
+    "funksjonsbryterne leses uten NEXT_PUBLIC_ for å holde dem utenfor klientbunten",
+};
+
+describe("skanningen", () => {
+  it("løser opp alle interne importer", () => {
+    // En intern import som ikke lot seg løse opp betyr at grafen mangler kanter,
+    // og da er reglene under målt på et ufullstendig bilde.
+    expect(scan.unresolved).toEqual([]);
+  });
+
+  it("finner filene i alle lagene", () => {
+    expect(scan.modules.length).toBeGreaterThan(0);
+    const layers = new Set(scan.modules.map((record) => record.id.split("/")[0]));
+    expect([...layers].sort()).toEqual([...LAYERS].sort());
+  });
+
+  it("skanner de samme mappene som grafen har lag for", () => {
+    // Dupliseringen mellom SCANNED_DIRECTORIES og LAYERS er bevisst; denne
+    // testen er prisen for den.
+    expect([...SCANNED_DIRECTORIES]).toEqual([...LAYERS]);
+  });
+});
+
+describe("den innsjekkede grafen", () => {
+  it("er oppdatert", () => {
+    const committed = readFileSync(join(root, GRAPH_FILE), "utf8");
+
+    expect(
+      committed,
+      `${GRAPH_FILE} er utdatert. Kjør: node scripts/architecture-graph.ts`,
+    ).toBe(serializeGraph(scan.modules));
+  });
+});
+
+describe("server/klient-grensen", () => {
+  it.each(Object.entries(SERVER_ONLY_MODULES))(
+    "%s shipper ikke til nettleseren",
+    (id, reason) => {
+      const record = scan.modules.find((candidate) => candidate.id === id);
+      expect(record, `${id} finnes ikke lenger. Oppdater SERVER_ONLY_MODULES.`).toBeDefined();
+
+      const importers = scan.modules
+        .filter((candidate) => candidate.imports.includes(id) && closure.has(candidate.id))
+        .map((candidate) => candidate.id);
+
+      expect(
+        closure.has(id),
+        `${id} havnet i klientbunten (${reason}). Nådd via: ${importers.join(", ")}.`,
+      ).toBe(false);
+    },
+  );
+
+  it("holder rutefilene på serveren", () => {
+    // AGENTS.md: «Keep route `page.tsx` files server-side and move interactive
+    // behavior into the smallest practical Client Component.»
+    const clientPages = scan.modules
+      .filter((record) => /^app\/.*page\.tsx$/.test(record.id))
+      .filter((record) => record.directive === "use client")
+      .map((record) => record.id);
+
+    expect(clientPages).toEqual([]);
+  });
+});
+
+/** Finner kall til `fetch(...)`, inkludert `globalThis.fetch(...)`, via AST-et. */
+function findFetchCalls(source: string, fileName: string): number {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  let count = 0;
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const target = node.expression;
+      const name = ts.isIdentifier(target)
+        ? target.text
+        : ts.isPropertyAccessExpression(target)
+          ? target.name.text
+          : null;
+      if (name === "fetch") count += 1;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  return count;
+}
+
+describe("dataflyten", () => {
+  it("kaller fetch bare fra services", () => {
+    // AGENTS.md: «Do not call `fetch` directly from `app`, `components`, or
+    // `providers`. Keep external I/O and Zod schemas in `services/api`.»
+    //
+    // AST framfor tekstsøk: et regex på "fetch(" treffer også kommentarer og
+    // strenger, og de kommentarene finnes faktisk i denne kodebasen.
+    const offenders = scan.modules
+      .filter((record) => !record.id.startsWith("services/"))
+      .filter((record) => findFetchCalls(readFileSync(join(root, record.id), "utf8"), record.id) > 0)
+      .map((record) => record.id);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/architecture-rules.test.ts
+++ b/scripts/architecture-rules.test.ts
@@ -18,13 +18,9 @@ import { describe, expect, it } from "vitest";
 import ts from "typescript";
 
 import { LAYERS, clientClosure } from "../lib/architecture";
-import {
-  GRAPH_FILE,
-  SCANNED_DIRECTORIES,
-  repositoryRoot,
-  scanRepository,
-  serializeGraph,
-} from "./architecture-graph";
+import { repositoryRoot } from "./architecture-graph.ts";
+import { SCANNED_DIRECTORIES, scanRepository } from "./architecture/scan.ts";
+import { GRAPH_FILE, serializeGraph } from "./architecture/serialize.ts";
 
 const root = repositoryRoot();
 const scan = scanRepository(root);

--- a/scripts/architecture/parse.test.ts
+++ b/scripts/architecture/parse.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { parseModule } from "./parse.ts";
+
+const specifiers = (source: string): string[] =>
+  parseModule(source, "components/Widget.tsx").specifiers;
+
+describe("parseModule", () => {
+  it("finner de vanlige importformene", () => {
+    expect(specifiers(`import { a } from "./a";`)).toEqual(["./a"]);
+    expect(specifiers(`import b from "./b";`)).toEqual(["./b"]);
+    expect(specifiers(`import * as c from "./c";`)).toEqual(["./c"]);
+    expect(specifiers(`export { d } from "./d";`)).toEqual(["./d"]);
+    expect(specifiers(`export * from "./e";`)).toEqual(["./e"]);
+    expect(specifiers(`const f = await import("./f");`)).toEqual(["./f"]);
+  });
+
+  it("tar med importer som bare kjøres for effekten sin", () => {
+    // `import "./styles.css"` har ingen bindinger, men filen lastes.
+    expect(specifiers(`import "./styles.css";`)).toEqual(["./styles.css"]);
+  });
+
+  describe("type-importer", () => {
+    // Disse forsvinner under kompilering, så de er ikke kanter i en graf som
+    // svarer på hva nettleseren laster ned.
+    it("dropper import type", () => {
+      expect(specifiers(`import type { A } from "./a";`)).toEqual([]);
+      expect(specifiers(`import type A from "./a";`)).toEqual([]);
+    });
+
+    it("dropper import { type A }", () => {
+      expect(specifiers(`import { type A } from "./a";`)).toEqual([]);
+      expect(specifiers(`import { type A, type B } from "./a";`)).toEqual([]);
+    });
+
+    it("dropper export type", () => {
+      expect(specifiers(`export type { A } from "./a";`)).toEqual([]);
+      expect(specifiers(`export { type A } from "./a";`)).toEqual([]);
+    });
+
+    it("beholder importen når minst én binding er en verdi", () => {
+      expect(specifiers(`import { type A, b } from "./a";`)).toEqual(["./a"]);
+      expect(specifiers(`import A, { type B } from "./a";`)).toEqual(["./a"]);
+      expect(specifiers(`export { type A, b } from "./a";`)).toEqual(["./a"]);
+    });
+
+    it("beholder export * selv om alt som eksporteres skulle være typer", () => {
+      // Uten å slå opp i modulen på andre siden er det umulig å vite, og en
+      // kant for mye er tryggere enn en for lite.
+      expect(specifiers(`export * from "./a";`)).toEqual(["./a"]);
+    });
+  });
+
+  describe("direktivet", () => {
+    it("leser et ledende direktiv", () => {
+      expect(parseModule(`"use client";\nexport const a = 1;`, "a.ts").directive).toBe(
+        "use client",
+      );
+      expect(parseModule(`"use server";`, "a.ts").directive).toBe("use server");
+    });
+
+    it("ser bort fra en streng som ikke står først", () => {
+      const source = `import { a } from "./a";\n"use client";`;
+      expect(parseModule(source, "a.ts").directive).toBeNull();
+    });
+
+    it("gir null når filen ikke har noe direktiv", () => {
+      expect(parseModule(`export const a = 1;`, "a.ts").directive).toBeNull();
+    });
+  });
+});

--- a/scripts/architecture/parse.ts
+++ b/scripts/architecture/parse.ts
@@ -1,0 +1,60 @@
+import ts from "typescript";
+
+export type ParsedModule = {
+  specifiers: string[];
+  directive: string | null;
+};
+
+/**
+ * Henter ut modulspesifikatorer og et eventuelt ledende direktiv.
+ *
+ * Bruker TypeScript-kompilatorens egen parser framfor regex. Det koster
+ * ingenting - `typescript` ligger allerede i devDependencies - og det er
+ * forskjellen på å finne alle importformene og å finne de fleste:
+ * `export ... from`, `import type` og `await import()` ser ikke like ut for et
+ * regex, men er alle ImportDeclaration/ExportDeclaration/ImportKeyword i AST-et.
+ *
+ * Direktivet må stå som første setning for at Next skal godta det, så vi leter
+ * bare der. En `"use client"` lenger ned i filen er en vanlig streng, og skal
+ * ikke tolkes som noe annet her heller.
+ */
+export function parseModule(source: string, fileName: string): ParsedModule {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  const [first] = sourceFile.statements;
+  const directive =
+    first && ts.isExpressionStatement(first) && ts.isStringLiteral(first.expression)
+      ? first.expression.text
+      : null;
+
+  return { specifiers, directive };
+}

--- a/scripts/architecture/parse.ts
+++ b/scripts/architecture/parse.ts
@@ -6,6 +6,41 @@ export type ParsedModule = {
 };
 
 /**
+ * True for importer og eksporter som forsvinner under kompilering.
+ *
+ * `import type`, `import { type Foo }` og `export type { Foo } from` finnes
+ * ikke i den ferdige koden, så de er ikke kanter i en graf som skal svare på
+ * hva nettleseren laster ned. Uten dette skillet fikk `components/master/edge/
+ * types.ts` - en fil som bare inneholder typedeklarasjoner og kompilerer til
+ * ingenting - stå som klientkode i grafen.
+ *
+ * Tvilstilfeller regnes som verdi-import. Retningen er ikke tilfeldig: en kant
+ * for mye gjør grafen litt for pessimistisk, mens en kant for lite kan la
+ * serverkode gli inn i klientbunten uten at porten i
+ * `architecture-rules.test.ts` merker det.
+ */
+function isTypeOnly(node: ts.ImportDeclaration | ts.ExportDeclaration): boolean {
+  if (ts.isExportDeclaration(node)) {
+    if (node.isTypeOnly) return true;
+    const clause = node.exportClause;
+    // `export * from` tar med verdiene også.
+    if (!clause || !ts.isNamedExports(clause) || clause.elements.length === 0) return false;
+    return clause.elements.every((element) => element.isTypeOnly);
+  }
+
+  const clause = node.importClause;
+  // `import "./styles.css"` har ingen bindinger og kjøres for effekten sin.
+  if (!clause) return false;
+  if (clause.isTypeOnly) return true;
+  // En default-import er alltid en verdi.
+  if (clause.name) return false;
+
+  const bindings = clause.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings) || bindings.elements.length === 0) return false;
+  return bindings.elements.every((element) => element.isTypeOnly);
+}
+
+/**
  * Henter ut modulspesifikatorer og et eventuelt ledende direktiv.
  *
  * Bruker TypeScript-kompilatorens egen parser framfor regex. Det koster
@@ -13,6 +48,7 @@ export type ParsedModule = {
  * forskjellen på å finne alle importformene og å finne de fleste:
  * `export ... from`, `import type` og `await import()` ser ikke like ut for et
  * regex, men er alle ImportDeclaration/ExportDeclaration/ImportKeyword i AST-et.
+ * Å skille verdi fra type krever uansett en parser.
  *
  * Direktivet må stå som første setning for at Next skal godta det, så vi leter
  * bare der. En `"use client"` lenger ned i filen er en vanlig streng, og skal
@@ -32,7 +68,8 @@ export function parseModule(source: string, fileName: string): ParsedModule {
     if (
       (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
       node.moduleSpecifier &&
-      ts.isStringLiteral(node.moduleSpecifier)
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      !isTypeOnly(node)
     ) {
       specifiers.push(node.moduleSpecifier.text);
     }

--- a/scripts/architecture/resolve.test.ts
+++ b/scripts/architecture/resolve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { repositoryRoot } from "../architecture-graph.ts";
+import { isInternalSpecifier, resolveSpecifier } from "./resolve.ts";
+
+const root = repositoryRoot();
+
+describe("resolveSpecifier", () => {
+  it("løser opp @/-aliaset mot repo-roten", () => {
+    expect(resolveSpecifier(root, "app/page.tsx", "@/lib/architecture")).toBe(
+      "lib/architecture.ts",
+    );
+  });
+
+  it("løser opp en relativ sti mot filen den står i", () => {
+    expect(resolveSpecifier(root, "scripts/architecture/scan.ts", "./resolve.ts")).toBe(
+      "scripts/architecture/resolve.ts",
+    );
+  });
+
+  it("gir null for pakker", () => {
+    expect(resolveSpecifier(root, "app/page.tsx", "react")).toBeNull();
+    expect(resolveSpecifier(root, "app/page.tsx", "next/image")).toBeNull();
+  });
+
+  it("nekter stier som peker ut av repoet", () => {
+    // Null her, ikke en node med et lag som ikke finnes. Spesifikatoren er
+    // intern, så `scanRepository` fører den opp som uløst og testen over
+    // feiler - høyt, ikke stille.
+    expect(resolveSpecifier(root, "app/page.tsx", "../../../etc/hosts")).toBeNull();
+    expect(resolveSpecifier(root, "app/page.tsx", "@/../package.json")).toBeNull();
+  });
+});
+
+describe("isInternalSpecifier", () => {
+  it("skiller interne stier fra pakker", () => {
+    expect(isInternalSpecifier("@/lib/a")).toBe(true);
+    expect(isInternalSpecifier("./a")).toBe(true);
+    expect(isInternalSpecifier("../a")).toBe(true);
+    expect(isInternalSpecifier("react")).toBe(false);
+    expect(isInternalSpecifier("next/image")).toBe(false);
+  });
+});

--- a/scripts/architecture/resolve.ts
+++ b/scripts/architecture/resolve.ts
@@ -1,0 +1,49 @@
+import { existsSync, statSync } from "node:fs";
+import { join, posix, sep } from "node:path";
+
+/** Rekkefølgen en bundler prøver når en spesifikator mangler filendelse. */
+const RESOLUTION_SUFFIXES = ["", ".ts", ".tsx", "/index.ts", "/index.tsx"];
+
+export function toPosix(path: string): string {
+  return path.split(sep).join("/");
+}
+
+/**
+ * Løser en spesifikator til en repo-relativ fil, eller `null` hvis den peker ut
+ * av repoet. `@/` er aliaset i tsconfig og peker på repo-roten.
+ *
+ * Dette er den naive utgaven av noe et bibliotek gjør grundigere: den kan `@/`
+ * og relative stier, ikke vilkårlige tsconfig-paths eller node_modules-oppslag.
+ * Det er trygt fordi den feiler høyt og ikke stille - `scanRepository` samler
+ * alt den ikke fikk løst i `unresolved`, og en test slår fast at lista er tom.
+ */
+export function resolveSpecifier(
+  root: string,
+  fromFile: string,
+  specifier: string,
+): string | null {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = specifier.slice(2);
+  } else if (specifier.startsWith(".")) {
+    base = posix.normalize(posix.join(posix.dirname(toPosix(fromFile)), specifier));
+  } else {
+    return null;
+  }
+
+  for (const suffix of RESOLUTION_SUFFIXES) {
+    const candidate = `${base}${suffix}`;
+    const absolute = join(root, candidate);
+    if (existsSync(absolute) && statSync(absolute).isFile()) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * True for spesifikatorer som _skal_ peke internt, altså der et oppslag som
+ * feiler er en feil og ikke et eksternt bibliotek.
+ */
+export function isInternalSpecifier(specifier: string): boolean {
+  return specifier.startsWith("@/") || specifier.startsWith(".");
+}

--- a/scripts/architecture/resolve.ts
+++ b/scripts/architecture/resolve.ts
@@ -31,6 +31,13 @@ export function resolveSpecifier(
     return null;
   }
 
+  // `../../../utenfor.ts` normaliserer til noe som starter med `..`, og
+  // `join(root, ...)` ville da pekt ut av repoet og gitt en node med et lag som
+  // ikke finnes. Null her sender den videre til `unresolved`, der en test
+  // fanger den opp.
+  base = posix.normalize(base);
+  if (base === ".." || base.startsWith("../") || posix.isAbsolute(base)) return null;
+
   for (const suffix of RESOLUTION_SUFFIXES) {
     const candidate = `${base}${suffix}`;
     const absolute = join(root, candidate);

--- a/scripts/architecture/scan.ts
+++ b/scripts/architecture/scan.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import type { ModuleRecord } from "../../lib/architecture";
+import { parseModule } from "./parse.ts";
+import { isInternalSpecifier, resolveSpecifier, toPosix } from "./resolve.ts";
+
+/**
+ * Mappene som utgjør applikasjonen.
+ *
+ * Duplisert fra `LAYERS` i `lib/architecture.ts`, siden denne fila kjøres av
+ * `node` og ikke skal dra applikasjonskode inn i et CLI. `architecture-rules.test.ts`
+ * slår fast at de to listene er like, så dupliseringen kan ikke drifte i stillhet.
+ */
+export const SCANNED_DIRECTORIES = [
+  "app",
+  "components",
+  "lib",
+  "providers",
+  "services",
+] as const;
+
+const SOURCE_FILE = /\.tsx?$/;
+const TEST_FILE = /\.test\.tsx?$/;
+const DECLARATION_FILE = /\.d\.ts$/;
+
+function collectSourceFiles(root: string, directory: string): string[] {
+  const absolute = join(root, directory);
+  if (!existsSync(absolute)) return [];
+
+  const found: string[] = [];
+  const visit = (current: string) => {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      // Tester og typedeklarasjoner er ikke en del av applikasjonsarkitekturen
+      // og shipper ikke, så de ville bare gjort grafen større uten å si noe.
+      if (
+        !SOURCE_FILE.test(entry) ||
+        TEST_FILE.test(entry) ||
+        DECLARATION_FILE.test(entry)
+      ) {
+        continue;
+      }
+      found.push(toPosix(relative(root, full)));
+    }
+  };
+
+  visit(absolute);
+  return found;
+}
+
+export type ScanResult = {
+  modules: ModuleRecord[];
+  /**
+   * Interne importer som ikke lot seg løse opp. Skal alltid være tom: en
+   * spesifikator som starter med `@/` eller `.` peker på en fil i repoet, og
+   * finner vi den ikke, har skanneren en blindsone. En ufullstendig graf som
+   * later som den er komplett er verre enn ingen graf.
+   */
+  unresolved: string[];
+};
+
+export function scanRepository(root: string): ScanResult {
+  const files = SCANNED_DIRECTORIES.flatMap((directory) =>
+    collectSourceFiles(root, directory),
+  );
+
+  const unresolved: string[] = [];
+  const modules = files.map((id): ModuleRecord => {
+    const { specifiers, directive } = parseModule(
+      readFileSync(join(root, id), "utf8"),
+      id,
+    );
+    const imports = new Set<string>();
+    const external = new Set<string>();
+
+    for (const specifier of specifiers) {
+      const resolved = resolveSpecifier(root, id, specifier);
+      if (resolved) {
+        // En fil som importerer seg selv er ikke en kant i grafen.
+        if (resolved !== id) imports.add(resolved);
+        continue;
+      }
+      if (isInternalSpecifier(specifier)) {
+        unresolved.push(`${id} -> ${specifier}`);
+        continue;
+      }
+      external.add(specifier);
+    }
+
+    return { id, directive, imports: [...imports], external: [...external] };
+  });
+
+  return { modules, unresolved };
+}

--- a/scripts/architecture/scan.ts
+++ b/scripts/architecture/scan.ts
@@ -68,6 +68,7 @@ export function scanRepository(root: string): ScanResult {
   const files = SCANNED_DIRECTORIES.flatMap((directory) =>
     collectSourceFiles(root, directory),
   );
+  const sourceFiles = new Set(files);
 
   const unresolved: string[] = [];
   const modules = files.map((id): ModuleRecord => {
@@ -81,8 +82,11 @@ export function scanRepository(root: string): ScanResult {
     for (const specifier of specifiers) {
       const resolved = resolveSpecifier(root, id, specifier);
       if (resolved) {
-        // En fil som importerer seg selv er ikke en kant i grafen.
-        if (resolved !== id) imports.add(resolved);
+        // Bare filer som selv er noder i grafen. `app/globals.css` og
+        // `data/architecture-graph.json` løses opp fint, men de er ikke
+        // kildefiler, og en kant til en node som ikke finnes er en løgn om
+        // grafen. En fil som importerer seg selv er heller ingen kant.
+        if (resolved !== id && sourceFiles.has(resolved)) imports.add(resolved);
         continue;
       }
       if (isInternalSpecifier(specifier)) {

--- a/scripts/architecture/serialize.ts
+++ b/scripts/architecture/serialize.ts
@@ -1,0 +1,29 @@
+import type { ModuleRecord } from "../../lib/architecture";
+
+export const GRAPH_FILE = "data/architecture-graph.json";
+
+/**
+ * Grafen som JSON, med nøklene i fast rekkefølge.
+ *
+ * Både filene og importene sorteres. Uten det ville diffen avhengt av
+ * rekkefølgen filsystemet ramser opp mapper i, og en generert fil som endrer seg
+ * uten at noe faktisk er endret er ubrukelig i en gjennomgang.
+ *
+ * Bare rå fakta lagres - hvilke filer finnes og hva de importerer. Om en fil
+ * ender opp på server eller klient regnes ut av `lib/architecture.ts`, så den
+ * avledningen finnes på ett sted og er dekket av tester.
+ */
+export function serializeGraph(modules: readonly ModuleRecord[]): string {
+  const payload = {
+    modules: [...modules]
+      .sort((first, second) => first.id.localeCompare(second.id))
+      .map((record) => ({
+        id: record.id,
+        directive: record.directive,
+        imports: [...record.imports].sort(),
+        external: [...record.external].sort(),
+      })),
+  };
+
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Nettsiden tegner sin egen arkitektur, og grensene i `AGENTS.md` håndheves nå av tester istedenfor å bare stå skrevet ned.

## Grafen

Et script leser importgrafen ut av `app`, `components`, `lib`, `providers` og `services` med TypeScripts egen parser, og skriver den til `data/architecture-graph.json` — 83 filer, 127 avhengigheter. Grafen sjekkes inn med vilje: da ser man i diffen når en klientkomponent plutselig trekker inn tre nye moduler, istedenfor at det bare skjer.

Visualiseringen ligger på `/architecture`. Noder farges etter om filen havner i nettleserbunten, størrelsen følger antall importører, og hover markerer en fil sammen med alt den henger sammen med.

## Gaten

Dette var egentlig poenget. Tre regler som ikke kan uttrykkes i ESLint, fordi de handler om forholdet *mellom* filer:

- `lib/features.ts` får ikke havne i klientbunten
- ingen `page.tsx` er en klientkomponent
- `fetch` kalles bare fra `services/`

Den første er den viktige. Du skrev selv i `lib/features.ts` at bryterne leses uten `NEXT_PUBLIC_` for at verdien skal bli på serveren — men en kommentar hindrer ingenting. Det holder at én `"use client"`-komponent importerer filen, så er brytertilstanden offentlig. Nå feiler testen og sier hvilken importør som gjorde det.

Regelen måles på nåbarhet, ikke på direktivet: en fil uten `"use client"` shipper likevel hvis en klientkomponent importerer den. 21 filer har direktivet, 59 ender opp i bunten.

Jeg brøt alle fire reglene med vilje og sjekket at de faktisk feilet før jeg stolte på dem. Grønt på kode som allerede er riktig beviser ingenting.

## Ting som måtte gjøres om underveis

Layouten var dårlig i første forsøk, og tallene sa hvorfor: nærmeste nodepar 0,0 px og 45 par tettere enn 14 px. Akkumulert hastighet med demping bygger opp energi, så nodene ble slynget ut i rammen og lagt i haug der klampingen stoppet dem. Byttet til Fruchterman-Reingold, som begrenser flyttet per steg med en temperatur som synker mot null. Minsteavstand nå 36 px.

Grafen fylte også bare halve bredden. Å presse simuleringen bred gjorde det verre — sterkere lagtrekk komprimerte den fra 44 % til 34 %, for ankerringen er mindre enn klumpen vil være. Løsningen ble å skille simuleringskoordinater fra rendring, og la en transform strekke resultatet ut i rammen.

Og en ekte bug: `Math.cos`/`Math.sin` er ikke pålagt å gi bit-identiske svar i Nodes V8 og Chromes V8. Det ga `779.2369769141981` mot `779.236976914198`, altså hydration mismatch på hver linje og sirkel. Koordinatene skrives nå bare på klienten — avrunding ville skjult det, ikke løst det, siden 300 iterasjoner kan forsterke avvik på siste bit.

Ingen nye dependencies, og ingen config-filer rørt. `typescript` lå alt i devDependencies, og Node 24 kjører `.ts` direkte.