### PR TITLE
feat: live cursors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import VisitTracker from "@/components/layout/VisitTracker";
+import LiveCursors from "@/components/cursors/LiveCursors";
 import { Analytics } from "@vercel/analytics/next";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
 
@@ -70,6 +71,7 @@ export default function RootLayout({
           <Footer />
         </ReactQueryProvider>
         <VisitTracker />
+        <LiveCursors />
         <Analytics />
         <Script
           src="https://analytics.vuhnger.dev/script.js"

--- a/components/cursors/CursorOverlay.tsx
+++ b/components/cursors/CursorOverlay.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { memo } from "react";
+import { usePathname } from "next/navigation";
+
+import { sanitizeRoom } from "@/lib/cursors";
+
+import { useCursors, type LiveCursor } from "./useCursors";
+
+const CURSOR_WIDTH = 13;
+const CURSOR_HEIGHT = 18;
+
+/**
+ * Musepeker med spissen i (1, 1.2), som er punktet `transform` flytter til.
+ *
+ * Underkanten av hodet er vannrett — de to siste punktene deler y. Det er den
+ * detaljen som gjør at formen leser som en peker: heller den kanten oppover mot
+ * høyre, blir det i stedet en trekant som peker til siden.
+ */
+const CURSOR_PATH = "M1 1.2 L1 16.6 L5.9 12.1 L11.7 12.1 Z";
+
+/**
+ * Memoisert fordi posisjonen ikke bor her: forelderen re-rendrer 15 ganger i
+ * sekundet per frame, men fargen er konstant per peer, så SVG-en trenger aldri
+ * å reconciles på nytt.
+ */
+const CursorGlyph = memo(({ color }: { color: string }) => (
+  <svg
+    width={CURSOR_WIDTH}
+    height={CURSOR_HEIGHT}
+    viewBox={`0 0 ${CURSOR_WIDTH} ${CURSOR_HEIGHT}`}
+    fill="none"
+    aria-hidden="true"
+    focusable="false"
+    style={{ display: "block", filter: "drop-shadow(0 1px 2px rgb(0 0 0 / 0.25))" }}
+  >
+    {/*
+      Konturen har bakgrunnsfargen, ikke hvit: den skal skille pilen fra det som
+      ligger under uansett om siden står i lyst eller mørkt tema. Serverens farge
+      er validert som `#rrggbb` før den kommer hit.
+    */}
+    <path
+      d={CURSOR_PATH}
+      fill={color}
+      stroke="var(--ds-color-neutral-background-default)"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+));
+CursorGlyph.displayName = "CursorGlyph";
+
+const PeerCursor = ({ peer, transitionMs }: { peer: LiveCursor; transitionMs: number }) => (
+  <span
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      // Koordinatene fra serveren er andeler av containeren, og `cqw`/`cqh` er
+      // nettopp prosent av containerens størrelse — så posisjoneringen trenger
+      // ingen måling i JS i det hele tatt. `transform` framfor `left`/`top`:
+      // posisjonene oppdateres 15 ganger i sekundet, og alt annet enn transform
+      // ville utløst layout hver gang.
+      transform: `translate3d(${peer.x * 100}cqw, ${peer.y * 100}cqh, 0)`,
+      transition: `transform ${transitionMs}ms linear`,
+      willChange: "transform",
+    }}
+  >
+    <CursorGlyph color={peer.color} />
+  </span>
+);
+
+/**
+ * Andres pekere, live, for alle som er inne på samme side.
+ *
+ * Rommet er `location.pathname`, så tilstedeværelsen er per side. Hele overlayet
+ * er `aria-hidden` og uten `pointer-events`: det er ren ambient informasjon som
+ * ikke skal dukke opp i en skjermleser eller stjele et klikk.
+ *
+ * Overlayet dekker viewporten minus et eventuelt rullefelt — samme boks som
+ * avsenderne normaliserer mot (`documentElement.clientWidth`). `100vw` ville
+ * talt med rullefeltet og skjøvet hver cursor litt mot høyre. `z-30` legger
+ * cursorene over innholdet, men under navbaren (`z-50`).
+ */
+const CursorOverlay = () => {
+  const pathname = usePathname();
+  const { peers, tickHz } = useCursors(sanitizeRoom(pathname));
+
+  // Frames kommer med `tickHz`. Matcher overgangen den raten, er hver cursor
+  // akkurat framme når neste frame lander — kortere gir hakking, lengre gir
+  // etterslep.
+  const transitionMs = Math.round(1000 / tickHz);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-30 overflow-hidden"
+      style={{ containerType: "size" }}
+    >
+      {peers.map((peer) => (
+        <PeerCursor key={peer.id} peer={peer} transitionMs={transitionMs} />
+      ))}
+    </div>
+  );
+};
+
+export default CursorOverlay;

--- a/components/cursors/LiveCursors.tsx
+++ b/components/cursors/LiveCursors.tsx
@@ -1,171 +1,23 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { usePathname } from "next/navigation";
+import dynamic from "next/dynamic";
 
-import { sanitizeRoom } from "@/lib/cursors";
-
-import { useCursors, useCursorsEnabled, type LiveCursor } from "./useCursors";
+import { useCursorsEnabled } from "./useCursors";
 
 /**
- * Over sideinnholdet, men under navbaren — en fremmed cursor skal ikke kunne
- * legge seg oppå navigasjonen.
+ * Selve overlayet lastes først når funksjonen faktisk er på: en mobil eller en
+ * bruker med `prefers-reduced-motion` skal ikke betale for kode som bare ville
+ * rendret null. `ssr: false` fordi tilkoblingen uansett ikke finnes uten en
+ * klient — det er ingenting å pre-rendre.
  */
-const OVERLAY_Z_INDEX = 30;
+const CursorOverlay = dynamic(() => import("./CursorOverlay"), { ssr: false });
 
-const CURSOR_WIDTH = 13;
-const CURSOR_HEIGHT = 18;
-
-/**
- * Musepeker med spissen i (1, 1.2), som er punktet `transform` flytter til.
- *
- * Underkanten av hodet er vannrett — de to siste punktene deler y. Det er den
- * detaljen som gjør at formen leser som en peker: heller den kanten oppover mot
- * høyre, blir det i stedet en trekant som peker til siden.
- */
-const CURSOR_PATH = "M1 1.2 L1 16.6 L5.9 12.1 L11.7 12.1 Z";
-
-type OverlaySize = { width: number; height: number };
-
-/**
- * Måler overlayet framfor å regne i `vw`/`vh`.
- *
- * Koordinatene fra serveren er andeler, ikke piksler, og skal ganges med
- * containerstørrelsen. `100vw` er ikke den størrelsen når det finnes et
- * vertikalt rullefelt — da er `vw` bredere enn det synlige området, og hver
- * cursor havner litt for langt til høyre. Målingen tar også høyde for at
- * mobilnettlesere endrer viewporthøyden når adresselinjen gjemmer seg.
- *
- * Bruker en callback-ref og ikke `useEffect` med `[]`: overlayet finnes ikke i
- * DOM ved første render — `useCursorsEnabled` starter som `false` og slår om
- * først etter hydrering. En effekt som kjørte én gang på mount ville sett en
- * tom ref, gitt opp, og aldri kjørt igjen. Da står `size` som `null` for alltid
- * og ingen cursor tegnes, selv om både socketen og overlayet er helt i orden.
- * React 19 kaller cleanupen som callback-refen returnerer når noden løsner.
- */
-function useOverlaySize(): [(node: HTMLDivElement | null) => void, OverlaySize | null] {
-  const [size, setSize] = useState<OverlaySize | null>(null);
-
-  const ref = useCallback((node: HTMLDivElement | null) => {
-    if (!node) return;
-
-    const apply = (width: number, height: number) => {
-      if (width <= 0 || height <= 0) return;
-      setSize((current) =>
-        current?.width === width && current?.height === height
-          ? current
-          : { width, height },
-      );
-    };
-
-    // Måles med en gang, ikke bare via observeren. En ResizeObserver leverer
-    // callbacken sin i «update the rendering»-steget, og det steget hoppes over
-    // i en fane som ikke tegnes. Uten denne linjen står `size` som `null` helt
-    // til fanen kommer i forgrunnen — og da tegnes ingen cursors i mellomtiden,
-    // selv om socketen har full oversikt over rommet.
-    apply(node.clientWidth, node.clientHeight);
-
-    const observer = new ResizeObserver((entries) => {
-      const box = entries[0]?.contentRect;
-      if (box) apply(box.width, box.height);
-    });
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, []);
-
-  return [ref, size];
-}
-
-const CursorGlyph = ({ color }: { color: string }) => (
-  <svg
-    width={CURSOR_WIDTH}
-    height={CURSOR_HEIGHT}
-    viewBox={`0 0 ${CURSOR_WIDTH} ${CURSOR_HEIGHT}`}
-    fill="none"
-    aria-hidden="true"
-    focusable="false"
-    style={{ display: "block", filter: "drop-shadow(0 1px 2px rgb(0 0 0 / 0.25))" }}
-  >
-    {/*
-      Konturen har bakgrunnsfargen, ikke hvit: den skal skille pilen fra det som
-      ligger under uansett om siden står i lyst eller mørkt tema. Serverens farge
-      er validert som `#rrggbb` før den kommer hit.
-    */}
-    <path
-      d={CURSOR_PATH}
-      fill={color}
-      stroke="var(--ds-color-neutral-background-default)"
-      strokeWidth="1.2"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
-const PeerCursor = ({
-  peer,
-  size,
-  transitionMs,
-}: {
-  peer: LiveCursor;
-  size: OverlaySize;
-  transitionMs: number;
-}) => (
-  <span
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      // `transform` framfor `left`/`top`: posisjonene oppdateres 15 ganger i
-      // sekundet, og alt annet enn transform ville utløst layout hver gang.
-      transform: `translate3d(${peer.x * size.width}px, ${peer.y * size.height}px, 0)`,
-      transition: `transform ${transitionMs}ms linear`,
-      willChange: "transform",
-    }}
-  >
-    <CursorGlyph color={peer.color} />
-  </span>
-);
-
-/**
- * Andres pekere, live, for alle som er inne på samme side.
- *
- * Rommet er `location.pathname`, så tilstedeværelsen er per side. Hele overlayet
- * er `aria-hidden` og uten `pointer-events`: det er ren ambient informasjon som
- * ikke skal dukke opp i en skjermleser eller stjele et klikk.
- */
 const LiveCursors = () => {
-  const pathname = usePathname();
   const enabled = useCursorsEnabled();
-  const { peers, tickHz } = useCursors(sanitizeRoom(pathname), enabled);
-  const [overlayRef, size] = useOverlaySize();
 
   if (!enabled) return null;
 
-  // Frames kommer med `tickHz`. Matcher overgangen den raten, er hver cursor
-  // akkurat framme når neste frame lander — kortere gir hakking, lengre gir
-  // etterslep.
-  const transitionMs = Math.round(1000 / tickHz);
-
-  return (
-    <div
-      ref={overlayRef}
-      aria-hidden="true"
-      style={{
-        position: "fixed",
-        inset: 0,
-        overflow: "hidden",
-        pointerEvents: "none",
-        zIndex: OVERLAY_Z_INDEX,
-      }}
-    >
-      {size
-        ? peers.map((peer) => (
-            <PeerCursor key={peer.id} peer={peer} size={size} transitionMs={transitionMs} />
-          ))
-        : null}
-    </div>
-  );
+  return <CursorOverlay />;
 };
 
 export default LiveCursors;

--- a/components/cursors/LiveCursors.tsx
+++ b/components/cursors/LiveCursors.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { usePathname } from "next/navigation";
 
 import { sanitizeRoom } from "@/lib/cursors";
@@ -26,26 +26,42 @@ type OverlaySize = { width: number; height: number };
  * vertikalt rullefelt — da er `vw` bredere enn det synlige området, og hver
  * cursor havner litt for langt til høyre. Målingen tar også høyde for at
  * mobilnettlesere endrer viewporthøyden når adresselinjen gjemmer seg.
+ *
+ * Bruker en callback-ref og ikke `useEffect` med `[]`: overlayet finnes ikke i
+ * DOM ved første render — `useCursorsEnabled` starter som `false` og slår om
+ * først etter hydrering. En effekt som kjørte én gang på mount ville sett en
+ * tom ref, gitt opp, og aldri kjørt igjen. Da står `size` som `null` for alltid
+ * og ingen cursor tegnes, selv om både socketen og overlayet er helt i orden.
+ * React 19 kaller cleanupen som callback-refen returnerer når noden løsner.
  */
-function useOverlaySize(): [React.RefObject<HTMLDivElement | null>, OverlaySize | null] {
-  const ref = useRef<HTMLDivElement>(null);
+function useOverlaySize(): [(node: HTMLDivElement | null) => void, OverlaySize | null] {
   const [size, setSize] = useState<OverlaySize | null>(null);
 
-  useEffect(() => {
-    const element = ref.current;
-    if (!element) return;
+  const ref = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+
+    const apply = (width: number, height: number) => {
+      if (width <= 0 || height <= 0) return;
+      setSize((current) =>
+        current?.width === width && current?.height === height
+          ? current
+          : { width, height },
+      );
+    };
+
+    // Måles med en gang, ikke bare via observeren. En ResizeObserver leverer
+    // callbacken sin i «update the rendering»-steget, og det steget hoppes over
+    // i en fane som ikke tegnes. Uten denne linjen står `size` som `null` helt
+    // til fanen kommer i forgrunnen — og da tegnes ingen cursors i mellomtiden,
+    // selv om socketen har full oversikt over rommet.
+    apply(node.clientWidth, node.clientHeight);
 
     const observer = new ResizeObserver((entries) => {
       const box = entries[0]?.contentRect;
-      if (!box || box.width <= 0 || box.height <= 0) return;
-      setSize((current) =>
-        current?.width === box.width && current?.height === box.height
-          ? current
-          : { width: box.width, height: box.height },
-      );
+      if (box) apply(box.width, box.height);
     });
 
-    observer.observe(element);
+    observer.observe(node);
     return () => observer.disconnect();
   }, []);
 

--- a/components/cursors/LiveCursors.tsx
+++ b/components/cursors/LiveCursors.tsx
@@ -13,8 +13,17 @@ import { useCursors, useCursorsEnabled, type LiveCursor } from "./useCursors";
  */
 const OVERLAY_Z_INDEX = 30;
 
-const CURSOR_WIDTH = 14;
+const CURSOR_WIDTH = 13;
 const CURSOR_HEIGHT = 18;
+
+/**
+ * Musepeker med spissen i (1, 1.2), som er punktet `transform` flytter til.
+ *
+ * Underkanten av hodet er vannrett — de to siste punktene deler y. Det er den
+ * detaljen som gjør at formen leser som en peker: heller den kanten oppover mot
+ * høyre, blir det i stedet en trekant som peker til siden.
+ */
+const CURSOR_PATH = "M1 1.2 L1 16.6 L5.9 12.1 L11.7 12.1 Z";
 
 type OverlaySize = { width: number; height: number };
 
@@ -84,10 +93,10 @@ const CursorGlyph = ({ color }: { color: string }) => (
       er validert som `#rrggbb` før den kommer hit.
     */}
     <path
-      d="M1 1 L1 16.4 L4.7 12.8 L11.4 10.8 Z"
+      d={CURSOR_PATH}
       fill={color}
       stroke="var(--ds-color-neutral-background-default)"
-      strokeWidth="1.5"
+      strokeWidth="1.2"
       strokeLinejoin="round"
     />
   </svg>

--- a/components/cursors/LiveCursors.tsx
+++ b/components/cursors/LiveCursors.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+import { sanitizeRoom } from "@/lib/cursors";
+
+import { useCursors, useCursorsEnabled, type LiveCursor } from "./useCursors";
+
+/**
+ * Over sideinnholdet, men under navbaren — en fremmed cursor skal ikke kunne
+ * legge seg oppå navigasjonen.
+ */
+const OVERLAY_Z_INDEX = 30;
+
+const CURSOR_WIDTH = 14;
+const CURSOR_HEIGHT = 18;
+
+type OverlaySize = { width: number; height: number };
+
+/**
+ * Måler overlayet framfor å regne i `vw`/`vh`.
+ *
+ * Koordinatene fra serveren er andeler, ikke piksler, og skal ganges med
+ * containerstørrelsen. `100vw` er ikke den størrelsen når det finnes et
+ * vertikalt rullefelt — da er `vw` bredere enn det synlige området, og hver
+ * cursor havner litt for langt til høyre. Målingen tar også høyde for at
+ * mobilnettlesere endrer viewporthøyden når adresselinjen gjemmer seg.
+ */
+function useOverlaySize(): [React.RefObject<HTMLDivElement | null>, OverlaySize | null] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState<OverlaySize | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect;
+      if (!box || box.width <= 0 || box.height <= 0) return;
+      setSize((current) =>
+        current?.width === box.width && current?.height === box.height
+          ? current
+          : { width: box.width, height: box.height },
+      );
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, size];
+}
+
+const CursorGlyph = ({ color }: { color: string }) => (
+  <svg
+    width={CURSOR_WIDTH}
+    height={CURSOR_HEIGHT}
+    viewBox={`0 0 ${CURSOR_WIDTH} ${CURSOR_HEIGHT}`}
+    fill="none"
+    aria-hidden="true"
+    focusable="false"
+    style={{ display: "block", filter: "drop-shadow(0 1px 2px rgb(0 0 0 / 0.25))" }}
+  >
+    {/*
+      Konturen har bakgrunnsfargen, ikke hvit: den skal skille pilen fra det som
+      ligger under uansett om siden står i lyst eller mørkt tema. Serverens farge
+      er validert som `#rrggbb` før den kommer hit.
+    */}
+    <path
+      d="M1 1 L1 16.4 L4.7 12.8 L11.4 10.8 Z"
+      fill={color}
+      stroke="var(--ds-color-neutral-background-default)"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const PeerCursor = ({
+  peer,
+  size,
+  transitionMs,
+}: {
+  peer: LiveCursor;
+  size: OverlaySize;
+  transitionMs: number;
+}) => (
+  <span
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      // `transform` framfor `left`/`top`: posisjonene oppdateres 15 ganger i
+      // sekundet, og alt annet enn transform ville utløst layout hver gang.
+      transform: `translate3d(${peer.x * size.width}px, ${peer.y * size.height}px, 0)`,
+      transition: `transform ${transitionMs}ms linear`,
+      willChange: "transform",
+    }}
+  >
+    <CursorGlyph color={peer.color} />
+  </span>
+);
+
+/**
+ * Andres pekere, live, for alle som er inne på samme side.
+ *
+ * Rommet er `location.pathname`, så tilstedeværelsen er per side. Hele overlayet
+ * er `aria-hidden` og uten `pointer-events`: det er ren ambient informasjon som
+ * ikke skal dukke opp i en skjermleser eller stjele et klikk.
+ */
+const LiveCursors = () => {
+  const pathname = usePathname();
+  const enabled = useCursorsEnabled();
+  const { peers, tickHz } = useCursors(sanitizeRoom(pathname), enabled);
+  const [overlayRef, size] = useOverlaySize();
+
+  if (!enabled) return null;
+
+  // Frames kommer med `tickHz`. Matcher overgangen den raten, er hver cursor
+  // akkurat framme når neste frame lander — kortere gir hakking, lengre gir
+  // etterslep.
+  const transitionMs = Math.round(1000 / tickHz);
+
+  return (
+    <div
+      ref={overlayRef}
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+        zIndex: OVERLAY_Z_INDEX,
+      }}
+    >
+      {size
+        ? peers.map((peer) => (
+            <PeerCursor key={peer.id} peer={peer} size={size} transitionMs={transitionMs} />
+          ))
+        : null}
+    </div>
+  );
+};
+
+export default LiveCursors;

--- a/components/cursors/useCursors.ts
+++ b/components/cursors/useCursors.ts
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import {
   MAX_PEERS,
   clampFraction,
+  pingInterval,
   reconnectDelay,
   shouldReconnect,
   viewportFraction,
@@ -17,18 +18,11 @@ import {
 } from "@/services/api/cursors";
 
 /**
- * Hvor ofte vi sender egen posisjon. Serveren samler opp og sender ut én
- * kombinert frame ved `tick_hz` (15), så alt over det blir slått sammen til
- * samme frame uansett og koster bare batteri. Over 60 meldinger i sekundet
- * stenges koblingen.
+ * Brukes til å tempo-sette både utsending og interpolasjon fram til `welcome`
+ * sier den faktiske raten. Å sende fortere enn serverens tick er bortkastet —
+ * alt over slås sammen til samme frame — og å sende saktere gir hakkete
+ * interpolasjon hos alle andre.
  */
-const SEND_HZ = 15;
-const SEND_INTERVAL_MS = 1000 / SEND_HZ;
-
-/** Serveren stenger etter 15 minutter uten trafikk. 30s gir god margin. */
-const PING_INTERVAL_MS = 30_000;
-
-/** Brukes til å tempo-sette interpolasjonen fram til `welcome` sier noe annet. */
 const DEFAULT_TICK_HZ = 15;
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
@@ -61,13 +55,15 @@ export type UseCursorsResult = {
 /**
  * Avgjør om cursors skal kobles opp i det hele tatt.
  *
- * To grunner til å la være, begge om brukeren framfor om nettverket:
+ * Tre grunner til å la være, alle om brukeren framfor om nettverket:
  *
  *  - `prefers-reduced-motion`: andres cursors er kontinuerlig, uforutsigbar
  *    bevegelse styrt av noen andre. Å bare gjøre interpolasjonen kortere hjelper
  *    ikke — bevegelsen er hele greia, så da dropper vi den.
  *  - `pointer: fine`: en touch-enhet har ingen cursor som svever. Det den ville
  *    sendt er hvor fingeren traff, som er støy for alle andre i rommet.
+ *  - container query-enheter: posisjonene tegnes i `cqw`/`cqh`. En nettleser
+ *    uten støtte ville stablet alle cursors i øverste venstre hjørne.
  */
 export function useCursorsEnabled(): boolean {
   // Starter som `false`: serveren rendrer uten matchMedia, og å anta «på» ville
@@ -75,6 +71,8 @@ export function useCursorsEnabled(): boolean {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
+    if (!CSS.supports("transform", "translate(1cqw, 1cqh)")) return;
+
     const reducedMotion = window.matchMedia(REDUCED_MOTION_QUERY);
     const finePointer = window.matchMedia(FINE_POINTER_QUERY);
     const update = () => setEnabled(finePointer.matches && !reducedMotion.matches);
@@ -97,26 +95,37 @@ export function useCursorsEnabled(): boolean {
  *
  * Alt av socket, timere og gjenoppkobling lever inne i én effekt. Det er med
  * vilje: da er «rydd opp» det samme som «kjør cleanup», og en socket kan ikke
- * overleve et rombytte ved et uhell.
+ * overleve et rombytte ved et uhell. Skal funksjonen skrus av, unmount
+ * komponenten som kaller hooken — cleanupen lukker socketen.
  */
-export function useCursors(room: string, enabled: boolean): UseCursorsResult {
+export function useCursors(room: string): UseCursorsResult {
   const [peers, setPeers] = useState<TrackedPeer[]>([]);
   const [tickHz, setTickHz] = useState(DEFAULT_TICK_HZ);
 
   useEffect(() => {
-    if (!enabled) return;
-
     const url = cursorSocketUrl(room);
     if (!url) return;
 
     let disposed = false;
     let socket: WebSocket | null = null;
     let attempt = 0;
+    /**
+     * Satt ved 1008: origin, romnavn og antall faner fra denne IP-en er de
+     * samme ved neste forsøk, så avvisningen er permanent. Uten flagget ville
+     * `onVisibilityChange` prøvd på nytt ved hvert fanebytte.
+     */
+    let refused = false;
     let reconnectTimer: number | undefined;
+    let sendTimer: number | undefined;
+    let pingTimer: number | undefined;
     /** Egen id, slik at vi kan droppe oss selv fra frames. */
     let selfId: string | null = null;
-    /** Siste pekerposisjon, sendt på timer framfor på hver `pointermove`. */
-    const pending = { x: 0, y: 0, dirty: false };
+    /**
+     * Siste pekerposisjon, sendt på timer framfor på hver `pointermove`.
+     * `has` skiller «aldri beveget» fra «beveget, men ikke sendt ennå» — den
+     * første skal ikke sende noe etter en reconnect, den andre skal.
+     */
+    const pending = { x: 0, y: 0, dirty: false, has: false };
 
     const clearPeers = () => setPeers((prev) => (prev.length === 0 ? prev : []));
 
@@ -134,8 +143,58 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
       }
     };
 
+    // En styreflate fyrer godt over 100 `pointermove` i sekundet. Serveren slår
+    // dem sammen uansett, så vi sampler til en variabel og sender på timer.
+    // `dirty` beholdes til socketen faktisk er åpen — ellers forsvinner den
+    // siste posisjonen under en reconnect, og brukeren forblir usynlig for
+    // rommet til neste fysiske musebevegelse.
+    const startSendTimer = (hz: number) => {
+      window.clearInterval(sendTimer);
+      sendTimer = window.setInterval(() => {
+        if (!pending.dirty || socket?.readyState !== WebSocket.OPEN) return;
+        pending.dirty = false;
+        trySend(cursorUpdateMessage(pending.x, pending.y));
+      }, 1000 / hz);
+    };
+
+    // `document.hidden` er hele mekanismen: en fane ingen ser på slutter å pinge
+    // og faller ut på idle-timeout av seg selv, framfor å okkupere en plass.
+    const startPingTimer = (ms: number) => {
+      window.clearInterval(pingTimer);
+      pingTimer = window.setInterval(() => {
+        if (document.hidden) return;
+        trySend(CURSOR_PING_MESSAGE);
+      }, ms);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      // `documentElement.clientWidth`, ikke `innerWidth`: samme boks som
+      // overlayet måles mot hos mottakerne. `innerWidth` teller med et
+      // eventuelt rullefelt, og den differansen ville forskjøvet cursoren
+      // med rullefeltbredden hos alle andre.
+      const x = viewportFraction(event.clientX, document.documentElement.clientWidth);
+      const y = viewportFraction(event.clientY, document.documentElement.clientHeight);
+      if (x === null || y === null) return;
+      pending.x = x;
+      pending.y = y;
+      pending.dirty = true;
+      pending.has = true;
+    };
+
+    /** En permanent avvisning skal ikke etterlate timere som spinner for ingenting. */
+    const giveUp = () => {
+      refused = true;
+      window.clearInterval(sendTimer);
+      window.clearInterval(pingTimer);
+      window.removeEventListener("pointermove", onPointerMove);
+    };
+
     const connect = () => {
-      if (disposed) return;
+      // En skjult fane kobler ikke opp — verken ved oppstart i bakgrunnen eller
+      // fra en reconnect-timer som fyrte etter at fanen ble gjemt. Den skal
+      // ikke holde en av rommets plasser; `onVisibilityChange` tar den når den
+      // kommer fram igjen.
+      if (disposed || document.hidden) return;
 
       let opened: WebSocket;
       try {
@@ -143,6 +202,7 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
       } catch {
         // Konstruktøren kaster bare på en ugyldig URL, og den er den samme
         // neste gang. Ingenting å prøve på nytt.
+        giveUp();
         return;
       }
       socket = opened;
@@ -153,10 +213,6 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
       // tømt det nye rommet.
       const isCurrent = () => !disposed && socket === opened;
 
-      opened.onopen = () => {
-        if (isCurrent()) attempt = 0;
-      };
-
       opened.onmessage = (event: MessageEvent) => {
         if (!isCurrent()) return;
         const message = parseCursorMessage(event.data);
@@ -164,8 +220,20 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
 
         switch (message.t) {
           case "welcome": {
+            // Først her, ikke i `onopen`: en server i en accept-så-lukk-løkke
+            // (full, restart) fullfører handshaket uten å slippe oss inn, og en
+            // nullstilling der ville holdt backoffen på minimum for alltid.
+            attempt = 0;
             selfId = message.id;
-            if (message.tick_hz) setTickHz(message.tick_hz);
+            if (message.tick_hz) {
+              setTickHz(message.tick_hz);
+              startSendTimer(message.tick_hz);
+            }
+            startPingTimer(pingInterval(message.idle_timeout_seconds));
+            // Rommet fikk aldri siste posisjon hvis bruddet kom mellom to
+            // sendinger. Har pekeren vært borti siden i det hele tatt, sendes
+            // den på nytt — ellers står vi uplassert til neste musebevegelse.
+            if (pending.has) pending.dirty = true;
             setPeers(
               message.peers
                 .filter((peer) => peer.id !== message.id)
@@ -205,7 +273,6 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
             setPeers((prev) => {
               let changed = false;
               const next = prev.map((peer) => {
-                if (!Object.hasOwn(message.c, peer.id)) return peer;
                 const moved = message.c[peer.id];
                 if (!moved) return peer;
 
@@ -238,46 +305,30 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
         // rommet *nå*, og å la den stå igjen tegner folk som kan ha gått.
         clearPeers();
 
-        if (!shouldReconnect(event.code)) return;
+        if (!shouldReconnect(event.code)) {
+          giveUp();
+          return;
+        }
+        // En fane som ble gjemt og idle-timet ut skal *ikke* rett inn igjen —
+        // det ville okkupert plassen på ubestemt tid og gjort hele
+        // ping-mekanismen meningsløs. Den kobler opp igjen når den blir synlig.
+        if (document.hidden) return;
         reconnectTimer = window.setTimeout(connect, reconnectDelay(attempt, Math.random()));
         attempt += 1;
       };
     };
 
-    const onPointerMove = (event: PointerEvent) => {
-      const x = viewportFraction(event.clientX, window.innerWidth);
-      const y = viewportFraction(event.clientY, window.innerHeight);
-      if (x === null || y === null) return;
-      pending.x = x;
-      pending.y = y;
-      pending.dirty = true;
-    };
-
-    // En styreflate fyrer godt over 100 `pointermove` i sekundet. Serveren slår
-    // dem sammen uansett, så vi sampler til en variabel og sender på timer.
-    const sendTimer = window.setInterval(() => {
-      if (!pending.dirty) return;
-      pending.dirty = false;
-      trySend(cursorUpdateMessage(pending.x, pending.y));
-    }, SEND_INTERVAL_MS);
-
-    // `document.hidden` er hele mekanismen: en fane ingen ser på slutter å pinge
-    // og faller ut på idle-timeout av seg selv, framfor å okkupere en plass.
-    const pingTimer = window.setInterval(() => {
-      if (document.hidden) return;
-      trySend(CURSOR_PING_MESSAGE);
-    }, PING_INTERVAL_MS);
-
     const onVisibilityChange = () => {
-      // Baksiden av det over: fanen ble stengt mens den lå i bakgrunnen. Kommer
-      // den fram igjen, skal den koble opp med en gang framfor å vente ut en
-      // backoff som ble målt for en helt annen situasjon.
-      if (disposed || document.hidden || socket !== null) return;
+      // Motstykket til at skjulte faner ikke kobler opp: kommer fanen fram
+      // igjen uten socket, skal den rett inn framfor å vente ut en backoff som
+      // ble målt for en helt annen situasjon.
+      if (disposed || refused || document.hidden || socket !== null) return;
       window.clearTimeout(reconnectTimer);
-      attempt = 0;
       connect();
     };
 
+    startSendTimer(DEFAULT_TICK_HZ);
+    startPingTimer(pingInterval(undefined));
     window.addEventListener("pointermove", onPointerMove, { passive: true });
     document.addEventListener("visibilitychange", onVisibilityChange);
     connect();
@@ -296,10 +347,10 @@ export function useCursors(room: string, enabled: boolean): UseCursorsResult {
       // cursors inn i det nye.
       clearPeers();
     };
-  }, [room, enabled]);
+  }, [room]);
 
   return {
-    peers: enabled ? peers.filter((peer) => peer.placed) : [],
+    peers: peers.filter((peer) => peer.placed),
     tickHz,
   };
 }

--- a/components/cursors/useCursors.ts
+++ b/components/cursors/useCursors.ts
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  MAX_PEERS,
+  clampFraction,
+  reconnectDelay,
+  shouldReconnect,
+  viewportFraction,
+} from "@/lib/cursors";
+import {
+  CURSOR_PING_MESSAGE,
+  cursorSocketUrl,
+  cursorUpdateMessage,
+  parseCursorMessage,
+} from "@/services/api/cursors";
+
+/**
+ * Hvor ofte vi sender egen posisjon. Serveren samler opp og sender ut én
+ * kombinert frame ved `tick_hz` (15), så alt over det blir slått sammen til
+ * samme frame uansett og koster bare batteri. Over 60 meldinger i sekundet
+ * stenges koblingen.
+ */
+const SEND_HZ = 15;
+const SEND_INTERVAL_MS = 1000 / SEND_HZ;
+
+/** Serveren stenger etter 15 minutter uten trafikk. 30s gir god margin. */
+const PING_INTERVAL_MS = 30_000;
+
+/** Brukes til å tempo-sette interpolasjonen fram til `welcome` sier noe annet. */
+const DEFAULT_TICK_HZ = 15;
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const FINE_POINTER_QUERY = "(pointer: fine)";
+
+export type LiveCursor = {
+  id: string;
+  color: string;
+  /** Andel av containeren, i [0, 1]. */
+  x: number;
+  y: number;
+};
+
+type TrackedPeer = LiveCursor & {
+  /**
+   * En som nettopp koblet til har ingen posisjon før første `frame`. Uten dette
+   * flagget måtte vi gjettet én — og en gjettet posisjon er en cursor som
+   * blinker opp midt på skjermen for noen som aldri har vært der.
+   */
+  placed: boolean;
+};
+
+export type UseCursorsResult = {
+  /** Peers med kjent posisjon. Egen cursor er ikke med. */
+  peers: LiveCursor[];
+  /** Serverens utsendingsrate, som interpolasjonen skal matche. */
+  tickHz: number;
+};
+
+/**
+ * Avgjør om cursors skal kobles opp i det hele tatt.
+ *
+ * To grunner til å la være, begge om brukeren framfor om nettverket:
+ *
+ *  - `prefers-reduced-motion`: andres cursors er kontinuerlig, uforutsigbar
+ *    bevegelse styrt av noen andre. Å bare gjøre interpolasjonen kortere hjelper
+ *    ikke — bevegelsen er hele greia, så da dropper vi den.
+ *  - `pointer: fine`: en touch-enhet har ingen cursor som svever. Det den ville
+ *    sendt er hvor fingeren traff, som er støy for alle andre i rommet.
+ */
+export function useCursorsEnabled(): boolean {
+  // Starter som `false`: serveren rendrer uten matchMedia, og å anta «på» ville
+  // gitt et hydreringsavvik på nettopp de enhetene som ikke skal ha funksjonen.
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia(REDUCED_MOTION_QUERY);
+    const finePointer = window.matchMedia(FINE_POINTER_QUERY);
+    const update = () => setEnabled(finePointer.matches && !reducedMotion.matches);
+
+    update();
+    reducedMotion.addEventListener("change", update);
+    finePointer.addEventListener("change", update);
+    return () => {
+      reducedMotion.removeEventListener("change", update);
+      finePointer.removeEventListener("change", update);
+    };
+  }, []);
+
+  return enabled;
+}
+
+/**
+ * Kobler til presence-rommet, strømmer egen pekerposisjon, og gir tilbake de
+ * andre i rommet.
+ *
+ * Alt av socket, timere og gjenoppkobling lever inne i én effekt. Det er med
+ * vilje: da er «rydd opp» det samme som «kjør cleanup», og en socket kan ikke
+ * overleve et rombytte ved et uhell.
+ */
+export function useCursors(room: string, enabled: boolean): UseCursorsResult {
+  const [peers, setPeers] = useState<TrackedPeer[]>([]);
+  const [tickHz, setTickHz] = useState(DEFAULT_TICK_HZ);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const url = cursorSocketUrl(room);
+    if (!url) return;
+
+    let disposed = false;
+    let socket: WebSocket | null = null;
+    let attempt = 0;
+    let reconnectTimer: number | undefined;
+    /** Egen id, slik at vi kan droppe oss selv fra frames. */
+    let selfId: string | null = null;
+    /** Siste pekerposisjon, sendt på timer framfor på hver `pointermove`. */
+    const pending = { x: 0, y: 0, dirty: false };
+
+    const clearPeers = () => setPeers((prev) => (prev.length === 0 ? prev : []));
+
+    /**
+     * `send` kan kaste hvis socketen rekker å lukke seg mellom sjekken av
+     * `readyState` og selve kallet. Det er ikke en feil verdt å reagere på —
+     * `onclose` er allerede på vei og tar gjenoppkoblingen.
+     */
+    const trySend = (payload: string) => {
+      if (socket?.readyState !== WebSocket.OPEN) return;
+      try {
+        socket.send(payload);
+      } catch {
+        // Ignorert med vilje. Se over.
+      }
+    };
+
+    const connect = () => {
+      if (disposed) return;
+
+      let opened: WebSocket;
+      try {
+        opened = new WebSocket(url);
+      } catch {
+        // Konstruktøren kaster bare på en ugyldig URL, og den er den samme
+        // neste gang. Ingenting å prøve på nytt.
+        return;
+      }
+      socket = opened;
+
+      // Alt under er portet på denne. Hendelser fra en socket fortsetter å komme
+      // etter at den er erstattet: bytt rom, og den gamle socketens `onclose`
+      // fyrer *etter* at den nye er åpen — en uportet `setPeers([])` ville da
+      // tømt det nye rommet.
+      const isCurrent = () => !disposed && socket === opened;
+
+      opened.onopen = () => {
+        if (isCurrent()) attempt = 0;
+      };
+
+      opened.onmessage = (event: MessageEvent) => {
+        if (!isCurrent()) return;
+        const message = parseCursorMessage(event.data);
+        if (!message) return;
+
+        switch (message.t) {
+          case "welcome": {
+            selfId = message.id;
+            if (message.tick_hz) setTickHz(message.tick_hz);
+            setPeers(
+              message.peers
+                .filter((peer) => peer.id !== message.id)
+                .slice(0, MAX_PEERS)
+                .map((peer) => ({
+                  id: peer.id,
+                  color: peer.color,
+                  x: clampFraction(peer.x ?? 0.5),
+                  y: clampFraction(peer.y ?? 0.5),
+                  placed: peer.x !== undefined && peer.y !== undefined,
+                })),
+            );
+            break;
+          }
+
+          case "join": {
+            if (message.id === selfId) break;
+            setPeers((prev) =>
+              prev.length >= MAX_PEERS || prev.some((peer) => peer.id === message.id)
+                ? prev
+                : [
+                    ...prev,
+                    { id: message.id, color: message.color, x: 0.5, y: 0.5, placed: false },
+                  ],
+            );
+            break;
+          }
+
+          case "leave":
+            setPeers((prev) => prev.filter((peer) => peer.id !== message.id));
+            break;
+
+          case "frame": {
+            // Samme bytes går til hele rommet framfor å serialiseres per
+            // mottaker, så din egen posisjon ligger i frame-en. Den er allerede
+            // ute av `peers` — egen id ble filtrert bort i `welcome`.
+            setPeers((prev) => {
+              let changed = false;
+              const next = prev.map((peer) => {
+                if (!Object.hasOwn(message.c, peer.id)) return peer;
+                const moved = message.c[peer.id];
+                if (!moved) return peer;
+
+                const x = clampFraction(moved[0]);
+                const y = clampFraction(moved[1]);
+                if (peer.placed && peer.x === x && peer.y === y) return peer;
+
+                changed = true;
+                return { ...peer, x, y, placed: true };
+              });
+              return changed ? next : prev;
+            });
+            break;
+          }
+
+          case "error":
+            console.warn("[cursors] avvist:", message.code);
+            break;
+
+          case "pong":
+            break;
+        }
+      };
+
+      opened.onclose = (event: CloseEvent) => {
+        if (!isCurrent()) return;
+        socket = null;
+        selfId = null;
+        // Tilstedeværelse overlever ikke et brudd: lista beskriver hvem som er i
+        // rommet *nå*, og å la den stå igjen tegner folk som kan ha gått.
+        clearPeers();
+
+        if (!shouldReconnect(event.code)) return;
+        reconnectTimer = window.setTimeout(connect, reconnectDelay(attempt, Math.random()));
+        attempt += 1;
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const x = viewportFraction(event.clientX, window.innerWidth);
+      const y = viewportFraction(event.clientY, window.innerHeight);
+      if (x === null || y === null) return;
+      pending.x = x;
+      pending.y = y;
+      pending.dirty = true;
+    };
+
+    // En styreflate fyrer godt over 100 `pointermove` i sekundet. Serveren slår
+    // dem sammen uansett, så vi sampler til en variabel og sender på timer.
+    const sendTimer = window.setInterval(() => {
+      if (!pending.dirty) return;
+      pending.dirty = false;
+      trySend(cursorUpdateMessage(pending.x, pending.y));
+    }, SEND_INTERVAL_MS);
+
+    // `document.hidden` er hele mekanismen: en fane ingen ser på slutter å pinge
+    // og faller ut på idle-timeout av seg selv, framfor å okkupere en plass.
+    const pingTimer = window.setInterval(() => {
+      if (document.hidden) return;
+      trySend(CURSOR_PING_MESSAGE);
+    }, PING_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      // Baksiden av det over: fanen ble stengt mens den lå i bakgrunnen. Kommer
+      // den fram igjen, skal den koble opp med en gang framfor å vente ut en
+      // backoff som ble målt for en helt annen situasjon.
+      if (disposed || document.hidden || socket !== null) return;
+      window.clearTimeout(reconnectTimer);
+      attempt = 0;
+      connect();
+    };
+
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    connect();
+
+    return () => {
+      disposed = true;
+      window.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.clearTimeout(reconnectTimer);
+      window.clearInterval(sendTimer);
+      window.clearInterval(pingTimer);
+      socket?.close(1000, "unmounted");
+      socket = null;
+      // Tømmes også her: ved rombytte er lukkingen vår egen, og `disposed` har
+      // allerede portet `onclose` bort. Uten dette overlever forrige roms
+      // cursors inn i det nye.
+      clearPeers();
+    };
+  }, [room, enabled]);
+
+  return {
+    peers: enabled ? peers.filter((peer) => peer.placed) : [],
+    tickHz,
+  };
+}

--- a/components/cursors/useCursors.ts
+++ b/components/cursors/useCursors.ts
@@ -71,6 +71,9 @@ export function useCursorsEnabled(): boolean {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
+    // `typeof`-sjekken er for jsdom, som mangler `CSS.supports`: en testkjøring
+    // skal behandle det som manglende støtte, ikke kaste.
+    if (typeof CSS === "undefined" || typeof CSS.supports !== "function") return;
     if (!CSS.supports("transform", "translate(1cqw, 1cqh)")) return;
 
     const reducedMotion = window.matchMedia(REDUCED_MOTION_QUERY);

--- a/lib/cursors.test.ts
+++ b/lib/cursors.test.ts
@@ -4,8 +4,10 @@ import {
   CLOSE_POLICY_VIOLATION,
   CURSOR_ROOM_MAX_LENGTH,
   DEFAULT_CURSOR_ROOM,
+  PING_INTERVAL_MAX_MS,
   RECONNECT_MAX_MS,
   clampFraction,
+  pingInterval,
   reconnectDelay,
   sanitizeRoom,
   shouldReconnect,
@@ -71,6 +73,28 @@ describe("viewportFraction", () => {
   it.each([0, -1, Number.NaN])("gir null for viewportstørrelse %p", (size) => {
     // Uten dette blir andelen `Infinity` eller `NaN` og går ut på socketen.
     expect(viewportFraction(100, size)).toBeNull();
+  });
+});
+
+describe("pingInterval", () => {
+  it("pinger flere ganger per idle-timeout", () => {
+    // Én tapt ping skal ikke koste tilstedeværelsen, så intervallet må være en
+    // god del kortere enn timeouten det holder unna.
+    expect(pingInterval(60)).toBe(20_000);
+  });
+
+  it("pinger aldri sjeldnere enn taket, uansett hvor romslig serveren er", () => {
+    expect(pingInterval(900)).toBe(PING_INTERVAL_MAX_MS);
+  });
+
+  it("faller tilbake til taket uten en oppgitt timeout", () => {
+    expect(pingInterval(undefined)).toBe(PING_INTERVAL_MAX_MS);
+  });
+
+  it("lar ikke en absurd timeout gjøre klienten om til en spammer", () => {
+    // Meldingsgrensen inn er 60/s; en timeout på under et sekund skal ikke
+    // presse pingene opp mot den.
+    expect(pingInterval(0.1)).toBeGreaterThanOrEqual(1000);
   });
 });
 

--- a/lib/cursors.test.ts
+++ b/lib/cursors.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CLOSE_POLICY_VIOLATION,
+  CURSOR_ROOM_MAX_LENGTH,
+  DEFAULT_CURSOR_ROOM,
+  RECONNECT_MAX_MS,
+  clampFraction,
+  reconnectDelay,
+  sanitizeRoom,
+  shouldReconnect,
+  viewportFraction,
+} from "./cursors";
+
+/** Tegnsettet serveren aksepterer. Testene under måles mot denne. */
+const LEGAL_ROOM = /^[A-Za-z0-9/_.-]+$/;
+
+describe("sanitizeRoom", () => {
+  it("lar en vanlig rute stå urørt", () => {
+    expect(sanitizeRoom("/projects/architecture")).toBe("/projects/architecture");
+  });
+
+  it.each([undefined, null, "", "?#", "æøå"])(
+    "faller tilbake til roten for %p",
+    (input) => {
+      // Alternativet er å hoppe over tilkoblingen helt. Roten er et lovlig rom,
+      // så heller litt for bred tilstedeværelse enn ingen.
+      expect(sanitizeRoom(input)).toBe(DEFAULT_CURSOR_ROOM);
+    },
+  );
+
+  it("fjerner tegn serveren ville avvist handshaket på", () => {
+    const room = sanitizeRoom("/søk?q=a b&x=1#topp");
+    expect(room).toMatch(LEGAL_ROOM);
+  });
+
+  it("korter ned til lengdegrensen", () => {
+    const room = sanitizeRoom(`/${"a".repeat(200)}`);
+    expect(room).toHaveLength(CURSOR_ROOM_MAX_LENGTH);
+  });
+});
+
+describe("clampFraction", () => {
+  it.each([
+    [0.42, 0.42],
+    [-3, 0],
+    [7, 1],
+  ])("klemmer %p til %p", (input, expected) => {
+    expect(clampFraction(input)).toBe(expected);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "gir en tegnbar verdi for %p",
+    (input) => {
+      // Verdien havner rett i en CSS-transform. `NaN` der gjør ikke bare denne
+      // cursoren usynlig, den gjør stilen ugyldig.
+      expect(Number.isFinite(clampFraction(input))).toBe(true);
+    },
+  );
+});
+
+describe("viewportFraction", () => {
+  it("regner om piksler til andel", () => {
+    expect(viewportFraction(320, 1280)).toBe(0.25);
+  });
+
+  it("klemmer en posisjon utenfor viewporten", () => {
+    expect(viewportFraction(-40, 800)).toBe(0);
+  });
+
+  it.each([0, -1, Number.NaN])("gir null for viewportstørrelse %p", (size) => {
+    // Uten dette blir andelen `Infinity` eller `NaN` og går ut på socketen.
+    expect(viewportFraction(100, size)).toBeNull();
+  });
+});
+
+describe("shouldReconnect", () => {
+  it("prøver ikke på nytt etter en policy-avvisning", () => {
+    // Origin, romnavn og antall faner fra IP-en er de samme neste gang.
+    expect(shouldReconnect(CLOSE_POLICY_VIOLATION)).toBe(false);
+  });
+
+  it.each([
+    [1000, "normal close, inkludert idle-timeout"],
+    [1006, "socketen døde uten close-frame"],
+    [1012, "serveren starter på nytt"],
+    [1013, "fullt, men kom gjerne tilbake"],
+  ])("prøver på nytt etter %i (%s)", (code) => {
+    expect(shouldReconnect(code)).toBe(true);
+  });
+});
+
+describe("reconnectDelay", () => {
+  it("øker eksponentielt", () => {
+    const jitter = 0.5;
+    expect(reconnectDelay(1, jitter)).toBeGreaterThan(reconnectDelay(0, jitter));
+    expect(reconnectDelay(3, jitter)).toBeGreaterThan(reconnectDelay(2, jitter));
+  });
+
+  it("holder seg under taket uansett antall forsøk", () => {
+    // Jitteren skalerer forsinkelsen ned, ikke opp. Ble den lagt oppå, ville et
+    // tak på 30s i praksis vært 45s.
+    for (const attempt of [0, 1, 5, 6, 50, 5000]) {
+      expect(reconnectDelay(attempt, 0.999)).toBeLessThanOrEqual(RECONNECT_MAX_MS);
+    }
+  });
+
+  it("sprer forsøkene ut i tid", () => {
+    // Poenget med jitter: alle åpne faner kobler opp igjen samtidig etter en
+    // deploy, og lik forsinkelse gjør dem til én bølge.
+    expect(reconnectDelay(4, 0)).not.toBe(reconnectDelay(4, 0.9));
+  });
+
+  it("er alltid positiv", () => {
+    expect(reconnectDelay(0, 0)).toBeGreaterThan(0);
+  });
+});

--- a/lib/cursors.test.ts
+++ b/lib/cursors.test.ts
@@ -138,4 +138,10 @@ describe("reconnectDelay", () => {
   it("er alltid positiv", () => {
     expect(reconnectDelay(0, 0)).toBeGreaterThan(0);
   });
+
+  it("gir en endelig forsinkelse selv for NaN", () => {
+    // NaN inn i `setTimeout` betyr 0ms — alle faner tilbake i samme øyeblikk.
+    expect(Number.isFinite(reconnectDelay(Number.NaN, Number.NaN))).toBe(true);
+    expect(reconnectDelay(Number.NaN, Number.NaN)).toBeGreaterThan(0);
+  });
 });

--- a/lib/cursors.ts
+++ b/lib/cursors.ts
@@ -1,0 +1,98 @@
+/**
+ * Ren logikk for live cursors: romnavn, koordinater og gjenoppkobling.
+ *
+ * Ligger her og ikke i hooken fordi det er nettopp disse reglene som har
+ * kanttilfeller verdt å teste — en hook full av timere og sockets er vond å
+ * teste, mens funksjonene under er rene og trivielle å kjøre.
+ */
+
+/** Serverens grense per rom. Speilet her for å begrense hva vi tegner. */
+export const MAX_PEERS = 50;
+
+/** Serveren avviser lengre romnavn i handshaket. */
+export const CURSOR_ROOM_MAX_LENGTH = 64;
+
+/** Serverens default når `room` ikke sendes. */
+export const DEFAULT_CURSOR_ROOM = "/";
+
+/** Tegnsettet serveren tillater i et romnavn. */
+const ROOM_DISALLOWED = /[^A-Za-z0-9/_.-]/g;
+
+/**
+ * Gjør en pathname om til et lovlig romnavn.
+ *
+ * Serveren validerer det samme og stenger med 1008 hvis det ikke stemmer, og
+ * 1008 er den ene koden vi ikke prøver på nytt. Et romnavn som ikke går gjennom
+ * ville altså slått av funksjonen for den siden helt, uten noen vei tilbake.
+ * Derfor renskes navnet her framfor å stole på at rutene alltid er ASCII.
+ *
+ * Renskingen kan i teorien slå to stier sammen til ett rom (`/a-b` og `/ab`
+ * hvis skilletegnet var ulovlig). Det er greit: verste utfall er at to sider
+ * deler tilstedeværelse, ikke at noe lekker.
+ */
+export function sanitizeRoom(pathname: string | null | undefined): string {
+  if (!pathname) return DEFAULT_CURSOR_ROOM;
+
+  const cleaned = pathname.replace(ROOM_DISALLOWED, "").slice(0, CURSOR_ROOM_MAX_LENGTH);
+  return cleaned.length > 0 ? cleaned : DEFAULT_CURSOR_ROOM;
+}
+
+/**
+ * Klemmer en koordinat inn i [0, 1].
+ *
+ * Serveren klemmer også, men frames vi mottar er tall vi skal gange med
+ * containerstørrelsen og sette rett inn i en transform. En verdi utenfor
+ * området ville plassert en cursor langt utenfor skjermen og potensielt gitt
+ * rullefelt; et tall som ikke er endelig ville gitt `NaN` i stilen.
+ */
+export function clampFraction(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Peker-posisjon som andel av viewporten.
+ *
+ * Returnerer `null` når viewporten ikke har noen størrelse — det skjer for en
+ * skjult iframe eller helt tidlig i oppstarten, og en divisjon på null ville
+ * gitt `Infinity` videre inn i protokollen.
+ */
+export function viewportFraction(position: number, size: number): number | null {
+  if (!Number.isFinite(position) || !Number.isFinite(size) || size <= 0) return null;
+  return clampFraction(position / size);
+}
+
+/** Policy-avvisning: feil origin, ulovlig rom, eller for mange faner fra samme IP. */
+export const CLOSE_POLICY_VIOLATION = 1008;
+
+/**
+ * 1008 er det eneste svaret gjentakelse ikke kan endre — origin, romnavn og
+ * antall faner fra denne IP-en er de samme ved neste forsøk. Å hamre på en
+ * avvisning er nettopp hvordan en grense blir til et selvpåført utfall.
+ */
+export function shouldReconnect(closeCode: number): boolean {
+  return closeCode !== CLOSE_POLICY_VIOLATION;
+}
+
+export const RECONNECT_BASE_MS = 500;
+export const RECONNECT_MAX_MS = 30_000;
+/** 500ms * 2^6 = 32s, altså over taket. Å telle høyere endrer ingenting. */
+export const RECONNECT_MAX_ATTEMPT = 6;
+
+/**
+ * Eksponentiell backoff med jitter.
+ *
+ * Jitteren er poenget, ikke pynt: den interessante feilen er at serveren
+ * starter på nytt, og da kobler alle åpne faner opp igjen samtidig. Med fast
+ * forsinkelse kommer de tilbake i samme øyeblikk og gjør en fem sekunders
+ * deploy om til et selvpåført lastspenn.
+ *
+ * `jitter` er en verdi i [0, 1) — `Math.random()` i produksjon, en fast verdi i
+ * test. Den skalerer resultatet til [0.5, 1) av full forsinkelse, slik at taket
+ * på 30s faktisk holder; å legge jitter oppå ville brutt det.
+ */
+export function reconnectDelay(attempt: number, jitter: number): number {
+  const bounded = Math.min(Math.max(attempt, 0), RECONNECT_MAX_ATTEMPT);
+  const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** bounded);
+  return backoff * (0.5 + Math.min(Math.max(jitter, 0), 0.999) * 0.5);
+}

--- a/lib/cursors.ts
+++ b/lib/cursors.ts
@@ -118,7 +118,11 @@ export const RECONNECT_MAX_ATTEMPT = 6;
  * på 30s faktisk holder; å legge jitter oppå ville brutt det.
  */
 export function reconnectDelay(attempt: number, jitter: number): number {
-  const bounded = Math.min(Math.max(attempt, 0), RECONNECT_MAX_ATTEMPT);
+  // `Math.min`/`Math.max` slipper NaN rett gjennom, og en NaN-forsinkelse inn i
+  // `setTimeout` fyrer umiddelbart — akkurat lastspennet backoffen skal hindre.
+  const safeAttempt = Number.isFinite(attempt) ? attempt : 0;
+  const safeJitter = Number.isFinite(jitter) ? jitter : 0;
+  const bounded = Math.min(Math.max(safeAttempt, 0), RECONNECT_MAX_ATTEMPT);
   const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** bounded);
-  return backoff * (0.5 + Math.min(Math.max(jitter, 0), 0.999) * 0.5);
+  return backoff * (0.5 + Math.min(Math.max(safeJitter, 0), 0.999) * 0.5);
 }

--- a/lib/cursors.ts
+++ b/lib/cursors.ts
@@ -6,8 +6,14 @@
  * teste, mens funksjonene under er rene og trivielle å kjøre.
  */
 
-/** Serverens grense per rom. Speilet her for å begrense hva vi tegner. */
-export const MAX_PEERS = 50;
+/**
+ * Sanity-tak på hvor mange peers vi holder i minne, med vilje godt over
+ * serverens romgrense (50). Å speile serverens eksakte grense ville betydd at
+ * en server-side økning stille kuttet roster-en her: en `join` forbi taket
+ * droppes for godt, og den personens frames matcher aldri noen — usynlig til
+ * neste reconnect. Taket skal bare stoppe en server som har løpt løpsk.
+ */
+export const MAX_PEERS = 200;
 
 /** Serveren avviser lengre romnavn i handshaket. */
 export const CURSOR_ROOM_MAX_LENGTH = 64;
@@ -60,6 +66,26 @@ export function clampFraction(value: number): number {
 export function viewportFraction(position: number, size: number): number | null {
   if (!Number.isFinite(position) || !Number.isFinite(size) || size <= 0) return null;
   return clampFraction(position / size);
+}
+
+/** Taket på hvor sjelden vi pinger. Holder med god margin på 15 min idle. */
+export const PING_INTERVAL_MAX_MS = 30_000;
+
+/**
+ * Hvor ofte en aktiv fane skal pinge, utledet av serverens egen idle-timeout.
+ *
+ * `welcome` oppgir timeouten, så den skal brukes framfor å anta 15 minutter: et
+ * miljø satt opp med en kortere timeout ville ellers lukket fanen før neste
+ * ping, som gir en koble-opp-og-falle-ut-løkke der ingen ser noe galt lokalt.
+ * En tredjedel gir rom for at én ping går tapt uten at det koster tilstedeværelsen.
+ */
+export function pingInterval(idleTimeoutSeconds: number | undefined): number {
+  if (!idleTimeoutSeconds || !Number.isFinite(idleTimeoutSeconds)) {
+    return PING_INTERVAL_MAX_MS;
+  }
+  // Nedre grense på ett sekund: en absurd liten timeout fra serveren skal ikke
+  // kunne gjøre klienten om til noe som spammer sin egen meldingsgrense.
+  return Math.max(1000, Math.min(PING_INTERVAL_MAX_MS, (idleTimeoutSeconds * 1000) / 3));
 }
 
 /** Policy-avvisning: feil origin, ulovlig rom, eller for mange faner fra samme IP. */

--- a/services/api/cursors.test.ts
+++ b/services/api/cursors.test.ts
@@ -40,6 +40,36 @@ describe("parseCursorMessage", () => {
     expect(message).toEqual({ t: "frame", c: { def: [0.1, 0.9] } });
   });
 
+  it("dropper et ugyldig frame-innslag uten å forkaste resten", () => {
+    // Én tilkobling som sender noe rart skal koste den tilkoblingen, ikke fryse
+    // samtlige cursors i rommet: zod feiler ellers hele recorden på ett innslag.
+    const message = parseCursorMessage(
+      JSON.stringify({
+        t: "frame",
+        c: { def: [0.1, 0.9], bad: [0.1], worse: "nope", ["x".repeat(100)]: [0.2, 0.2] },
+      }),
+    );
+
+    expect(message).toEqual({ t: "frame", c: { def: [0.1, 0.9] } });
+  });
+
+  it("slår ikke opp i Object.prototype for ukjente frame-nøkler", () => {
+    const message = parseCursorMessage(JSON.stringify({ t: "frame", c: {} }));
+
+    expect(message?.t === "frame" && message.c["constructor"]).toBeUndefined();
+  });
+
+  it("dropper en ugyldig peer i welcome uten å forkaste resten", () => {
+    const message = parseCursorMessage(
+      JSON.stringify({
+        ...welcome,
+        peers: [{ id: "def", color: "#0ea5e9" }, { id: "ghi", color: "ikke-en-farge" }],
+      }),
+    );
+
+    expect(message?.t === "welcome" && message.peers).toEqual([{ id: "def", color: "#0ea5e9" }]);
+  });
+
   it("avviser en farge som ikke er en hex-farge", () => {
     // `color` går rett inn i en SVG-fill. En streng som ikke har formen vi har
     // bestemt, skal aldri komme så langt.
@@ -60,7 +90,6 @@ describe("parseCursorMessage", () => {
   it.each([
     ["ukjent meldingstype", JSON.stringify({ t: "banana" })],
     ["ødelagt JSON", "{ ikke json"],
-    ["frame med feil arity", JSON.stringify({ t: "frame", c: { def: [0.1] } })],
     ["welcome uten id", JSON.stringify({ t: "welcome", color: "#ffffff", peers: [] })],
     ["ren tekst", "hei"],
   ])("gir null for %s", (_label, payload) => {
@@ -89,10 +118,17 @@ describe("parseCursorMessage", () => {
 });
 
 describe("cursorSocketUrl", () => {
-  it("bruker wss og legger rommet i query", () => {
+  // Verten kommer fra `NEXT_PUBLIC_API_BASE_URL` og varierer med miljøet, så
+  // testen sjekker formen framfor en bestemt adresse — en literal ville brutt
+  // `pnpm run check` for alle som peker mot en lokal backend.
+  it("bruker ws-protokoll og legger rommet i query", () => {
     const url = cursorSocketUrl("/projects");
 
-    expect(url).toBe("wss://api.vuhnger.dev/site/ws/cursors?room=%2Fprojects");
+    expect(url).not.toBeNull();
+    const parsed = new URL(url as string);
+    expect(["ws:", "wss:"]).toContain(parsed.protocol);
+    expect(parsed.pathname).toBe("/site/ws/cursors");
+    expect(parsed.searchParams.get("room")).toBe("/projects");
   });
 });
 

--- a/services/api/cursors.test.ts
+++ b/services/api/cursors.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CURSOR_PING_MESSAGE,
+  cursorSocketUrl,
+  cursorUpdateMessage,
+  parseCursorMessage,
+} from "./cursors";
+
+const welcome = {
+  t: "welcome",
+  id: "abc",
+  color: "#e11d48",
+  peers: [{ id: "def", color: "#0ea5e9", x: 0.5, y: 0.25 }],
+  tick_hz: 15,
+  idle_timeout_seconds: 900,
+};
+
+describe("parseCursorMessage", () => {
+  it("leser en welcome med full romtilstand", () => {
+    const message = parseCursorMessage(JSON.stringify(welcome));
+
+    expect(message).toEqual(expect.objectContaining({ t: "welcome", id: "abc" }));
+    expect(message?.t === "welcome" && message.peers).toHaveLength(1);
+  });
+
+  it("godtar en peer uten posisjon", () => {
+    // Noen som nettopp koblet til har ikke rukket å bevege pekeren. Å avvise
+    // hele welcome-en for det ville tømt rommet for alle andre også.
+    const message = parseCursorMessage(
+      JSON.stringify({ ...welcome, peers: [{ id: "def", color: "#0ea5e9" }] }),
+    );
+
+    expect(message?.t).toBe("welcome");
+  });
+
+  it("leser en frame", () => {
+    const message = parseCursorMessage(JSON.stringify({ t: "frame", c: { def: [0.1, 0.9] } }));
+
+    expect(message).toEqual({ t: "frame", c: { def: [0.1, 0.9] } });
+  });
+
+  it("avviser en farge som ikke er en hex-farge", () => {
+    // `color` går rett inn i en SVG-fill. En streng som ikke har formen vi har
+    // bestemt, skal aldri komme så langt.
+    expect(
+      parseCursorMessage(JSON.stringify({ t: "join", id: "def", color: "url(#x)" })),
+    ).toBeNull();
+    expect(
+      parseCursorMessage(JSON.stringify({ t: "join", id: "def", color: "red" })),
+    ).toBeNull();
+  });
+
+  it("avviser en id uten grenser", () => {
+    expect(
+      parseCursorMessage(JSON.stringify({ t: "leave", id: "x".repeat(500) })),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["ukjent meldingstype", JSON.stringify({ t: "banana" })],
+    ["ødelagt JSON", "{ ikke json"],
+    ["frame med feil arity", JSON.stringify({ t: "frame", c: { def: [0.1] } })],
+    ["welcome uten id", JSON.stringify({ t: "welcome", color: "#ffffff", peers: [] })],
+    ["ren tekst", "hei"],
+  ])("gir null for %s", (_label, payload) => {
+    expect(parseCursorMessage(payload)).toBeNull();
+  });
+
+  it.each([null, undefined, 42, { t: "pong" }, new ArrayBuffer(8)])(
+    "gir null for ikke-tekst %p",
+    (payload) => {
+      // `MessageEvent.data` er `any`. Binære rammer er ikke en del av protokollen.
+      expect(parseCursorMessage(payload)).toBeNull();
+    },
+  );
+
+  it("nekter å parse en urimelig stor melding", () => {
+    // Beskytter mot å bruke fanen på `JSON.parse` av noe vi aldri ba om.
+    const huge = JSON.stringify({ t: "error", code: "x".repeat(200_000) });
+    expect(parseCursorMessage(huge)).toBeNull();
+  });
+
+  it("kaster aldri", () => {
+    for (const payload of ["", "[]", "null", "0", '{"t":null}', "{}"]) {
+      expect(() => parseCursorMessage(payload)).not.toThrow();
+    }
+  });
+});
+
+describe("cursorSocketUrl", () => {
+  it("bruker wss og legger rommet i query", () => {
+    const url = cursorSocketUrl("/projects");
+
+    expect(url).toBe("wss://api.vuhnger.dev/site/ws/cursors?room=%2Fprojects");
+  });
+});
+
+describe("klientmeldinger", () => {
+  it("sender posisjon som andel", () => {
+    expect(cursorUpdateMessage(0.51, 0.28)).toBe('{"t":"cursor","x":0.51,"y":0.28}');
+  });
+
+  it("har en ferdig serialisert ping", () => {
+    // Sendes hvert 30. sekund; det er ingen grunn til å bygge strengen på nytt.
+    expect(CURSOR_PING_MESSAGE).toBe('{"t":"ping"}');
+  });
+});

--- a/services/api/cursors.ts
+++ b/services/api/cursors.ts
@@ -34,11 +34,24 @@ const peerSchema = z.object({
   y: coordinateSchema.optional(),
 });
 
+/**
+ * Én ugyldig peer skal koste den peeren, ikke hele meldingen. Zod feiler ellers
+ * hele recorden/arrayen på ett dårlig innslag, og både `welcome` og `frame`
+ * beskriver alle i rommet — å forkaste dem kollektivt ville fryst samtlige
+ * cursors fordi én tilkobling sendte noe rart.
+ */
+const tolerantPeersSchema = z.array(z.unknown()).transform((list) =>
+  list.flatMap((entry) => {
+    const parsed = peerSchema.safeParse(entry);
+    return parsed.success ? [parsed.data] : [];
+  }),
+);
+
 const welcomeSchema = z.object({
   t: z.literal("welcome"),
   id: peerIdSchema,
   color: colorSchema,
-  peers: z.array(peerSchema),
+  peers: tolerantPeersSchema,
   tick_hz: z.number().positive().max(120).optional(),
   idle_timeout_seconds: z.number().positive().optional(),
 });
@@ -54,9 +67,22 @@ const leaveSchema = z.object({
   id: peerIdSchema,
 });
 
+const coordinatePairSchema = z.tuple([coordinateSchema, coordinateSchema]);
+
+// Samme prinsipp som `tolerantPeersSchema`. Resultatet bygges uten prototype,
+// slik at et oppslag på en id som ikke er med (f.eks. "constructor") gir
+// `undefined` og ikke noe arvet fra `Object.prototype`.
 const frameSchema = z.object({
   t: z.literal("frame"),
-  c: z.record(peerIdSchema, z.tuple([coordinateSchema, coordinateSchema])),
+  c: z.record(z.string(), z.unknown()).transform((entries) => {
+    const valid: Record<string, [number, number]> = Object.create(null);
+    for (const [id, value] of Object.entries(entries)) {
+      if (id.length === 0 || id.length > 64) continue;
+      const parsed = coordinatePairSchema.safeParse(value);
+      if (parsed.success) valid[id] = parsed.data;
+    }
+    return valid;
+  }),
 });
 
 const pongSchema = z.object({ t: z.literal("pong") });
@@ -76,7 +102,6 @@ const serverMessageSchema = z.discriminatedUnion("t", [
 ]);
 
 export type CursorServerMessage = z.output<typeof serverMessageSchema>;
-export type CursorPeerSnapshot = z.output<typeof peerSchema>;
 
 /**
  * Tak på hvor mye vi i det hele tatt forsøker å parse. En `welcome` med 50 peers

--- a/services/api/cursors.ts
+++ b/services/api/cursors.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+import { API_BASE_URL } from "./client";
+
+/**
+ * Protokollgrensen mot `WS /site/ws/cursors`.
+ *
+ * Meldingene fra serveren er ekstern JSON på lik linje med et HTTP-svar, så de
+ * parses med Zod før de får lov til å bety noe. Det er ikke bare formalisme her:
+ * `color` går rett inn i en CSS-verdi og `id` blir en oppslagsnøkkel, så begge
+ * må ha en form vi har bestemt selv.
+ */
+
+/** Serveren tildeler farger som `#rrggbb`. Alt annet er ikke en farge vi tegner. */
+const colorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/);
+
+/**
+ * IDene er ugjennomsiktige for oss; det eneste som betyr noe er at de er korte
+ * strenger. Grensen hindrer at en id på en megabyte havner i en React-nøkkel.
+ */
+const peerIdSchema = z.string().min(1).max(64);
+
+const coordinateSchema = z.number();
+
+/**
+ * `welcome.peers` beskriver hele romtilstanden. `x`/`y` er valgfrie fordi noen
+ * som nettopp koblet til ikke nødvendigvis har rukket å bevege pekeren; da har
+ * de ingen posisjon å tegnes på ennå.
+ */
+const peerSchema = z.object({
+  id: peerIdSchema,
+  color: colorSchema,
+  x: coordinateSchema.optional(),
+  y: coordinateSchema.optional(),
+});
+
+const welcomeSchema = z.object({
+  t: z.literal("welcome"),
+  id: peerIdSchema,
+  color: colorSchema,
+  peers: z.array(peerSchema),
+  tick_hz: z.number().positive().max(120).optional(),
+  idle_timeout_seconds: z.number().positive().optional(),
+});
+
+const joinSchema = z.object({
+  t: z.literal("join"),
+  id: peerIdSchema,
+  color: colorSchema,
+});
+
+const leaveSchema = z.object({
+  t: z.literal("leave"),
+  id: peerIdSchema,
+});
+
+const frameSchema = z.object({
+  t: z.literal("frame"),
+  c: z.record(peerIdSchema, z.tuple([coordinateSchema, coordinateSchema])),
+});
+
+const pongSchema = z.object({ t: z.literal("pong") });
+
+const errorSchema = z.object({
+  t: z.literal("error"),
+  code: z.string().max(64),
+});
+
+const serverMessageSchema = z.discriminatedUnion("t", [
+  welcomeSchema,
+  joinSchema,
+  leaveSchema,
+  frameSchema,
+  pongSchema,
+  errorSchema,
+]);
+
+export type CursorServerMessage = z.output<typeof serverMessageSchema>;
+export type CursorPeerSnapshot = z.output<typeof peerSchema>;
+
+/**
+ * Tak på hvor mye vi i det hele tatt forsøker å parse. En `welcome` med 50 peers
+ * er noen få kilobyte; alt over dette er ikke en melding vi har bedt om, og
+ * `JSON.parse` på en vilkårlig stor streng er en gratis måte å fryse fanen på.
+ */
+const MAX_MESSAGE_LENGTH = 64 * 1024;
+
+/**
+ * Parser en melding fra serveren, eller gir `null`.
+ *
+ * Kaster aldri. En ødelagt melding skal ikke velte socketen — den skal ignoreres,
+ * slik at neste `frame` retter opp bildet av seg selv.
+ */
+export function parseCursorMessage(data: unknown): CursorServerMessage | null {
+  if (typeof data !== "string" || data.length > MAX_MESSAGE_LENGTH) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(data);
+  } catch {
+    return null;
+  }
+
+  const result = serverMessageSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Bygger WebSocket-URLen for et rom.
+ *
+ * Gir `null` hvis `NEXT_PUBLIC_API_BASE_URL` ikke er en gyldig URL. Feilen er en
+ * feilkonfigurasjon, ikke noe brukeren kan gjøre noe med, og cursors er pynt —
+ * den skal droppe seg selv i stillhet framfor å kaste under render.
+ */
+export function cursorSocketUrl(room: string): string | null {
+  try {
+    const url = new URL("/site/ws/cursors", API_BASE_URL);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    url.searchParams.set("room", room);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Posisjon som andel av viewporten. Serveren klemmer verdier utenfor [0, 1]. */
+export function cursorUpdateMessage(x: number, y: number): string {
+  return JSON.stringify({ t: "cursor", x, y });
+}
+
+/** Holder en aktiv fane i live forbi idle-timeouten. Besvares med `pong`. */
+export const CURSOR_PING_MESSAGE = JSON.stringify({ t: "ping" });


### PR DESCRIPTION
Kobler siden på `wss://api.vuhnger.dev/site/ws/cursors` og tegner cursorene til alle andre som er inne på samme side samtidig.

Rommet er `location.pathname`, så tilstedeværelsen er per side — du ser bare folk som er på samme sted som deg. Koordinatene fra serveren er andeler av viewporten, ikke piksler, så overlayet måles med en ResizeObserver og posisjonene ganges opp mot den faktiske størrelsen. `100vw` funker ikke her, det tar ikke hensyn til rullefeltet.

Splittet i tre: `lib/cursors.ts` har den rene logikken (romnavn, klemming, backoff), `services/api/cursors.ts` har Zod-skjemaene for protokollen, og `components/cursors/` har hooken og rendringen. Fargen serveren tildeler går rett inn i en SVG-fill, så den valideres som `#rrggbb` før den kommer dit.

Kobler ikke opp i det hele tatt ved `prefers-reduced-motion` eller på touch-enheter — andres cursors er kontinuerlig bevegelse du ikke styrer selv, og en finger som tapper har ingen posisjon verdt å sende.